### PR TITLE
Integration Tests for Example Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ test_debug: debug
 	python3 udfs.py
 	ASAN_OPTIONS=detect_leaks=1 ./build/debug/test/unittest --test-dir . "[sql]"
 
+test_examples_debug:
+	PYTHONPATH=examples ASAN_OPTIONS=detect_leaks=1 ./build/debug/test/unittest --test-dir . "[sql]"
+
+test_examples_release:
+	PYTHONPATH=examples ./build/release/test/unittest --test-dir . "[sql]"
+
 check-format:
 	find src/ -iname '*.hpp' -o -iname '*.cpp' | xargs clang-format -Werror --sort-includes=0 -style=file --dry-run
 

--- a/test/sql/pytable_examples.test
+++ b/test/sql/pytable_examples.test
@@ -1,0 +1,25 @@
+# name: test/sql/pytable_examples.test
+# description: test provided Python functions for the python_table extension function
+# group: [python_table_examples]
+
+# Require statement will ensure this test is run with this extension loaded
+require python_udf
+
+
+# Confirm our example function for the README works as expected
+query III
+SELECT *
+FROM python_table('ghub:repos_for', 'markroddy',
+                  columns = {'repo': 'VARCHAR', 'description': 'VARCHAR', 'language': 'VARCHAR'})
+WHERE language = 'Python' AND repo = 'boto';
+----
+boto	Python interface to Amazon Web Services	Python
+
+
+# Enumerate S3 Objects
+query IIII
+SELECT *
+FROM python_table('aws:s3_objects', 'net.ednit.duckdb-extensions', 'python_udf/097089c/v0.7.1/linux_amd64/',
+     columns = { 'key': 'VARCHAR', 'last_modified': 'VARCHAR', 'size': 'INT', 'storage_class': 'VARCHAR'});
+----
+python_udf/097089c/v0.7.1/linux_amd64/python_udf.duckdb_extension.gz	03/29/2023	7356670	STANDARD


### PR DESCRIPTION
This is currently a WIP and some what of a holding ground for bits of SQL I've written to exercise example Table Functions.


These are hard to integrate into the test suite for two reasons:
1. Most require external auth (password or API key) because they're hitting an external service. These can be added to CI, but because of this we don't want the run as part of the standard test suite when invoked locally.
2. I can't figure out how to exclude them from the test runner 🤷