### PR TITLE
Update python version pin for local dev from 3.9 -> 3.8

### DIFF
--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -20,7 +20,7 @@ runs:
         apt-get install -y -qq software-properties-common
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
-        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client python3.8-dev python3.8-venv
+        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client python3.8-dev python3.8-venv python3.8-distutils
 
 
     - name: Install
@@ -38,6 +38,7 @@ runs:
       shell: bash
       run: |
         python3.8 --version
+        curl https://bootstrap.pypa.io/get-pip.py | python3.8
         python3.8 -m pip install pip
         python3.8 -m pip install requests awscli
 

--- a/.github/actions/ubuntu_16_setup/action.yml
+++ b/.github/actions/ubuntu_16_setup/action.yml
@@ -20,7 +20,8 @@ runs:
         apt-get install -y -qq software-properties-common
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
-        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client python3.9-dev python3-pip python3.9-venv
+        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client python3.8-dev python3.8-venv
+
 
     - name: Install
       shell: bash
@@ -32,17 +33,13 @@ runs:
       with:
         fetch-depth: 0
 
-    # - uses: actions/setup-python@v2
-    #   with:
-    #     python-version: '3.9'
-
-    - name: Install Python 3.7
+    - name: Install Python Packages
       if: ${{ inputs.python }} == 1
       shell: bash
       run: |
-        python3.9 --version
-        python3.9 -m pip install pip
-        python3.9 -m pip install requests awscli
+        python3.8 --version
+        python3.8 -m pip install pip
+        python3.8 -m pip install requests awscli
 
     - name: Install CMake 3.21
       shell: bash
@@ -84,6 +81,6 @@ runs:
       shell: bash
       run: |
         ldd --version ldd
-        python3.9 --version
+        python3.8 --version
         git --version
         git log -1 --format=%h

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -98,17 +98,6 @@ jobs:
       uses: ./.github/actions/ubuntu_16_setup
       with:
         aarch64_cross_compile: ${{ matrix.arch == 'linux_arm64' && 1 }}
-
-    - name: Tell me about your python install
-      # Debugging step, comment to re-enable
-      if: 0 == 1
-      run: |
-        ls -ld /usr/include/python*
-        which python || echo "No 'python' executable"
-        which python3 || echo "No 'python3' executable"
-        python -V || echo "No 'python' executable"
-        python3 -V || echo "No 'python3' executable"
-        ls -l /usr/include/python3.9/*.h
       
       # Build extension
     - name: Build extension

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: release
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
-PYTHON_VERSION := $(if $(PYTHON_VERSION),$(PYTHON_VERSION),3.9)
+PYTHON_VERSION := $(if $(PYTHON_VERSION),$(PYTHON_VERSION),3.8)
 EXTENSION_VERSION := $(shell cat pythonpkgs/ducktables/version.txt)
 DUCKDB_VERSION := $(if $(DUCKDB_VERSION),$(DUCKDB_VERSION),0.8.0)
 
@@ -71,6 +71,7 @@ python-test-integration:
 
 # Tests a build of the extension against a download of DuckDB
 extension-integration-tests:
+	if [ -z "$(GITHUB_ACCESS_TOKEN)" ]; then echo "Missing GITHUB_ACCESS_TOKEN needed for testing"; exit 1; fi
 	cp pythonpkgs/ducktables/dist/ducktables-$(EXTENSION_VERSION)-py3-none-any.whl test/extension-integration/
 	cp build/release/extension/pytables/pytables.duckdb_extension test/extension-integration/
 	cd test/extension-integration/ && \

--- a/scripts/python-ci.sh
+++ b/scripts/python-ci.sh
@@ -6,11 +6,11 @@ echo "Entering python land..."
 cd pythonpkgs/
 
 echo "Checking that we have a python..."
-which python3.9
+which python3.8
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python3.9 -m venv myenv
+python3.8 -m venv myenv
 echo "Sourcing the env"
 source myenv/bin/activate
 

--- a/scripts/python-release.sh
+++ b/scripts/python-release.sh
@@ -6,11 +6,11 @@ echo "Entering python land..."
 cd pythonpkgs/
 
 echo "Checking that we have a python..."
-which python3.9
+which python3.8
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python3.9 -m venv myenv
+python3.8 -m venv myenv
 echo "Sourcing the env"
 source myenv/bin/activate
 
@@ -22,7 +22,7 @@ pip install --upgrade pip
 pip install wheel
 
 
-python3.9 setup.py sdist bdist_wheel
+python3.8 setup.py sdist bdist_wheel
 
 
 # Install Twine to interact with PyPi

--- a/scripts/python-test-integration.sh
+++ b/scripts/python-test-integration.sh
@@ -11,11 +11,11 @@ echo "Entering python land..."
 cd pythonpkgs/
 
 echo "Checking that we have a python..."
-which python3.9
+which python3.8
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python3.9 -m venv myenv
+python3.8 -m venv myenv
 echo "Sourcing the env"
 source myenv/bin/activate
 


### PR DESCRIPTION
I stood up a new dev box in EC2 and 3.8 is the default install. My previous box had 3.9 installed on top of it, and that created a bunch of problems. Going to work with the system version for now.