### PR TITLE
DuckTables Functions Declare Output Schema

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+
+((c++-mode . ((indent-tabs-mode . t)
+              (c-basic-offset . 4)
+              (tab-width . 4))))

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -126,10 +126,11 @@ jobs:
       run: |
         make python-ci
 
-    - name: Run Integration Tests
+    - name: Extension + Python Integration Tests
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         make GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} DUCKDB_VERSION=${{ env.DUCKDB_VERSION }} extension-integration-tests
+        make python-test-integration
 
     # Can't test the installer against a version of DuckDB that we've never produced binaries for before.
     # todo: conditionally run this if the installer has changed

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -134,7 +134,7 @@ jobs:
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON_B64 }}" | base64 --decode > gcloud-creds.json         
-        make AWS_DEFAULT_REGION=us-west-2 OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        make AWS_ACCESS_KEY_ID=${{ secrets.S3_DEPLOY_ID }} AWS_SECRET_ACCESS_KEY=${{ secrets.S3_DEPLOY_KEY }} AWS_DEFAULT_REGION=${{ secrets.S3_REGION }} OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -131,7 +131,7 @@ jobs:
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON_B64 }}" | base64 --decode > gcloud-creds.json         
-        make OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        make OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }} OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -45,7 +45,10 @@ jobs:
 
     - name: Setup Python ${{ matrix.python_version }}
       run: |
-        apt-get install -y -qq python${{ matrix.python_version }}-dev
+        apt-get install -y -qq python${{ matrix.python_version }}-dev python${PYTHON_VERSION}-distutils python${PYTHON_VERSION}-venv
+        curl https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION};
+        python$PYTHON_VERSION -m pip install --upgrade pip && \
+        python$PYTHON_VERSION -m venv --help
   
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -130,7 +130,8 @@ jobs:
     - name: Python Integration Tests
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
-        make GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON_B64" | base64 --decode > gcloud-creds.json         
+        make GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -130,8 +130,8 @@ jobs:
     - name: Python Integration Tests
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
-        echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON_B64" | base64 --decode > gcloud-creds.json         
-        make GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON_B64 }}" | base64 --decode > gcloud-creds.json         
+        make OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -134,7 +134,7 @@ jobs:
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON_B64 }}" | base64 --decode > gcloud-creds.json         
-        make AWS_REGION=us-west-2 OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        make AWS_DEFAULT_REGION=us-west-2 OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -134,7 +134,7 @@ jobs:
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON_B64 }}" | base64 --decode > gcloud-creds.json         
-        make OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        make AWS_REGION=us-west-2 OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -131,7 +131,7 @@ jobs:
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON_B64 }}" | base64 --decode > gcloud-creds.json         
-        make OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }} OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+        make OPENAI_ORG_ID="${{ secrets.OPENAI_ORG_ID }}" OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" GOOGLE_APPLICATION_CREDENTIALS=gcloud-creds.json GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
 
     # Runs the extension against the official DuckDB binary (versus the one built w/this project)
     - name: Extension Integration Tests

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -126,11 +126,17 @@ jobs:
       run: |
         make python-ci
 
-    - name: Extension + Python Integration Tests
+    # Runs the extension + DuckTables functions against the actual APIs they work with
+    - name: Python Integration Tests
+      if: ${{ '<submodule_version>' != matrix.duckdb_version }}
+      run: |
+        make GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} python-test-integration
+
+    # Runs the extension against the official DuckDB binary (versus the one built w/this project)
+    - name: Extension Integration Tests
       if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         make GITHUB_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} DUCKDB_VERSION=${{ env.DUCKDB_VERSION }} extension-integration-tests
-        make python-test-integration
 
     # Can't test the installer against a version of DuckDB that we've never produced binaries for before.
     # todo: conditionally run this if the installer has changed

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ test/python/__pycache__/
 .Rhistory
 stuff/*
 duckdb-*
-pythonpkgs/myenv/
+pythonpkgs/env-py*/
 pythonpkgs/ducktables/dist/
 pythonpkgs/ducktables/ducktables.egg-info/
 test/extension-integration/pytables.duckdb_extension

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 include_directories(src/include ${Python_INCLUDE_DIRS})
 
-FILE(GLOB EXTENSION_SOURCES src/*.cpp)
+FILE(GLOB_RECURSE EXTENSION_SOURCES src/*.cpp)
 
 # Define Py_LIMITED_API for all source files, pins us to Python 3.4.
 add_definitions(-DPy_LIMITED_API=0x03040000)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,11 @@ RUN wget https://www.openssl.org/source/openssl-1.1.1c.tar.gz && \
 # Install Target Version of Python
 ARG PYTHON_VERSION
 RUN test -n "$PYTHON_VERSION" && \
-    apt-get install -y -qq python${PYTHON_VERSION}-dev
+    apt-get install -y -qq python${PYTHON_VERSION}-dev python${PYTHON_VERSION} libpython${PYTHON_VERSION} python${PYTHON_VERSION}-distutils python${PYTHON_VERSION}-venv && \
+    curl https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} && \
+    python$PYTHON_VERSION -m pip install --upgrade pip && \
+    python$PYTHON_VERSION -m venv --help
+
 
 
 # Setup the development environment

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,13 @@ python-release:
 	rm -f pythonpkgs/ducktables/dist/duck*
 	bash ./scripts/python-release.sh
 
+# Runs DuckDB SQL using functions provided by the Python package. Note that since most of these functions require
+# some kind of auth, you will likely have trouble running these locally without a lot of (presently) undocumented setup.
 python-test-integration:
+	@if [ -z "$(GITHUB_ACCESS_TOKEN)" ]; then echo "Missing GITHUB_ACCESS_TOKEN needed for testing"; exit 1; fi
+	@if [ -z "$(GOOGLE_APPLICATION_CREDENTIALS)" ]; then echo "Missing GOOGLE_APPLICATION_CREDENTIALS needed for testing"; exit 1; fi
+	@if [ -z "$(OPENAI_API_KEY)" ]; then echo "Missing OPENAI_API_KEY needed for testing"; exit 1; fi
+	@if [ -z "$(OPENAI_ORG_ID)" ]; then echo "Missing OPENAI_ORG_ID needed for testing"; exit 1; fi
 	bash ./scripts/python-test-integration.sh
 
 # Tests a build of the extension against a download of DuckDB

--- a/pythonpkgs/ducktables/README.md
+++ b/pythonpkgs/ducktables/README.md
@@ -48,30 +48,13 @@ Note that all queries will assume to run in the region you have specified in you
 ### EC2 Instances
 Returns the results of a [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) API call.
 ```sql
-    SELECT * FROM pytable('aws:ec2_instances',
-      columns = {
-        'instance_id': 'VARCHAR',
-        'name': 'VARCHAR',
-        'instance_type': 'VARCHAR',
-        'state': 'VARCHAR',
-        'key_pair': 'VARCHAR',
-        'platform': 'VARCHAR',
-        'architecture': 'VARCHAR',
-        'vpc_id': 'VARCHAR',
-        'subnet_id': 'VARCHAR',
-        'public_dns': 'VARCHAR',
-        'public_ip': 'VARCHAR',
-        'private_dns': 'VARCHAR',
-        'private_ip': 'VARCHAR'
-        });
+    SELECT * FROM pytable('ducktables.aws:ec2_instances');
 ```
 
 ### S3 Buckets
 Returns the results of a [ListBuckets](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html) API call.
 ```SQL
-SELECT * FROM pytable('aws:s3_buckets', 
-  columns={'name': 'VARCHAR', 'creation_date': 'VARCHAR'}
-);
+SELECT * FROM pytable('ducktables.aws:s3_buckets');
 ```
 
 ### S3 Objects
@@ -79,17 +62,13 @@ This only includes metadata about the objects themselves, not their contents. Se
 
 Note that the second argument, the prefix path, is optional and can be omitted.
 ```SQL
-SELECT * FROM pytable('aws:s3_objects', 'bucket-name', 'foo/bar/prefix',
-  columns = { 'key': 'VARCHAR', 'last_modified': 'VARCHAR', 'size': 'INT', 'storage_class': 'VARCHAR'}
-);
+SELECT * FROM pytable('ducktables.aws:s3_objects', 'bucket-name', 'foo/bar/prefix');
 ```
 
 ## Github
 Enumerates all repositories for the named user or organization.
 ```SQL
-SELECT * FROM pytable('ghub:repos_for', 'duckdb',
-  columns = {'repo': 'VARCHAR', 'description': 'VARCHAR', 'language': 'VARCHAR'}
-);
+SELECT * FROM pytable('ducktables.githb:repos_for', 'duckdb');
 ```
 
 ## Open AI

--- a/pythonpkgs/ducktables/ducktables/__init__.py
+++ b/pythonpkgs/ducktables/ducktables/__init__.py
@@ -11,7 +11,6 @@ class DuckTableSchemaWrapper:
 
     def column_names(self, *args, **kwargs):
         if self.names:
-            print("Returning an explicit set of %s column names" % len(self.names), file=sys.stderr)
             return self.names
         else:
             return self.names_from_types(*args, **kwargs)
@@ -24,7 +23,6 @@ class DuckTableSchemaWrapper:
 
     def column_types(self, *args, **kwargs):
         if self.types:
-            print("Returning an explicit set of %s column types" % len(self.types), file=sys.stderr)
             return self.types
         else:
             return self.types_from_signature()

--- a/pythonpkgs/ducktables/ducktables/__init__.py
+++ b/pythonpkgs/ducktables/ducktables/__init__.py
@@ -1,19 +1,35 @@
 
-import inspect
+import inspect, sys
 from typing import Any, Optional, Dict, Iterable
 
 class DuckTableSchemaWrapper:
 
-    def __init__(self, func):
+    def __init__(self, func, names = None, types = None):
         self.func = func
+        self.types = types
+        self.names = names
 
     def column_names(self, *args, **kwargs):
+        if self.names:
+            print("Returning an explicit set of %s column names" % len(self.names), file=sys.stderr)
+            return self.names
+        else:
+            return self.names_from_types(*args, **kwargs)
+
+    def names_from_types(self, *args, **kwargs):
         col_types = self.column_types(*args, **kwargs)
         if not col_types:
             return None
         return [f'column{i + 1}' for i in range(len(col_types))]
 
     def column_types(self, *args, **kwargs):
+        if self.types:
+            print("Returning an explicit set of %s column types" % len(self.types), file=sys.stderr)
+            return self.types
+        else:
+            return self.types_from_signature()
+
+    def types_from_signature(self):
         sig = inspect.signature(self.func)
         return_type = sig.return_annotation
         if sig.return_annotation == inspect.Signature.empty:
@@ -33,6 +49,22 @@ class DuckTableSchemaWrapper:
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)
 
-def ducktable(func):
-    return DuckTableSchemaWrapper(func)
+def ducktable(*args, **kwargs):
+    if (1 == len(args)) and (0 == len(kwargs)) and callable(args[0]):
+        # No arguments, this is the decorator
+        # We just return the decorated function
+        return DuckTableSchemaWrapper(args[0])
+    else:
+        # User has supplied a set of arguments to the decorator when they
+        # decoratored their function. This means they specified columns or
+        # columns and types.
+        if kwargs:
+            names = tuple(kwargs.keys())
+            types = tuple(kwargs.values())
+        else:
+            names = args
+            types = None
+        def decorator(func):
+            return DuckTableSchemaWrapper(func, names, types)
+        return decorator
 

--- a/pythonpkgs/ducktables/ducktables/aws.py
+++ b/pythonpkgs/ducktables/ducktables/aws.py
@@ -1,26 +1,27 @@
 
 import boto3
+from ducktables import ducktable
 
-
+_ec2_instances_schema = {
+    'instance_id': str,
+    'name': str,
+    'instance_type': str,
+    'state': str,
+    'key_pair': str,
+    'platform': str,
+    'architecture': str,
+    'vpc_id': str,
+    'subnet_id': str,
+    'public_dns': str,
+    'public_ip': str,
+    'private_dns': str,
+    'private_ip': str,
+    }
+@ducktable(**_ec2_instances_schema)
 def ec2_instances():
     """
     SQL Usage:
-    SELECT * FROM pytable('aws:ec2_instances',
-      columns = {
-        'instance_id': 'VARCHAR',
-        'name': 'VARCHAR',
-        'instance_type': 'VARCHAR',
-        'state': 'VARCHAR',
-        'key_pair': 'VARCHAR',
-        'platform': 'VARCHAR',
-        'architecture': 'VARCHAR',
-        'vpc_id': 'VARCHAR',
-        'subnet_id': 'VARCHAR',
-        'public_dns': 'VARCHAR',
-        'public_ip': 'VARCHAR',
-        'private_dns': 'VARCHAR',
-        'private_ip': 'VARCHAR'
-        });
+    SELECT * FROM pytable('aws:ec2_instances'));
     """
     def response_to_rows(response):
         for resv in response['Reservations']:
@@ -59,30 +60,26 @@ def ec2_instances():
         token = response.get('NextToken')
         
         
-
+@ducktable(name = str, creation_date = str)
 def s3_buckets():
     """
     SQL Usage:
-    SELECT * FROM pytable('aws:s3_buckets', columns={'name': 'VARCHAR', 'creation_date': 'VARCHAR'});
+    SELECT * FROM pytable('aws:s3_buckets');
     """
     client = boto3.client('s3')
     response = client.list_buckets()
     for bucket in response['Buckets']:
         yield (bucket['Name'], bucket['CreationDate'].strftime('%m/%d/%Y'))
     
-
+@ducktable(key = str, last_modified = str, size = int, storage_class = str)
 def s3_objects(bucket, prefix = None):
     """
     SQL Usage:
-    SELECT * FROM pytable('aws:s3_objects', 'bucket-name', 'foo/bar/prefix',
-      columns = { 'key': 'VARCHAR', 'last_modified': 'VARCHAR', 'size': 'INT', 'storage_class': 'VARCHAR'}
-    );
+    SELECT * FROM pytable('aws:s3_objects', 'bucket-name', 'foo/bar/prefix');
 
     Note that the final prefix argument is optional, and you don't need to specify it in
     your SQL query. To list all objects:
-    SELECT * FROM python_table('aws', 's3_objects',
-      { 'key': 'VARCHAR', 'last_modified': 'VARCHAR', 'size': 'INT', 'storage_class': 'VARCHAR'},
-      ['bucket-name']);
+    SELECT * FROM pytable('aws:s3_objects', 'bucket-name');
     """
     def to_row(obj):
         return (obj['Key'],

--- a/pythonpkgs/ducktables/ducktables/github.py
+++ b/pythonpkgs/ducktables/ducktables/github.py
@@ -1,10 +1,12 @@
 
 import os, sys
 from github import Github
+from ducktables import ducktable
 
 token = os.environ.get("GITHUB_ACCESS_TOKEN")
 g = Github(token)
 
+@ducktable(repo = str, description = str, language = str)
 def repos_for(username):
     for r in g.get_user(username).get_repos():
         yield (r.name, r.description, r.language)

--- a/pythonpkgs/ducktables/ducktables/openai.py
+++ b/pythonpkgs/ducktables/ducktables/openai.py
@@ -6,12 +6,13 @@ import openai
 openai.organization = os.getenv("OPENAI_ORG_ID")
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+from ducktables import ducktable
+
+@ducktable(index = int, message = str, message_role = str, finish_reason = str)
 def prompt(input_phrase, num_responses = 5):
     """
     SQL Usage:
-    SELECT * FROM pytable('chatgpt:prompt', 'Write a limerick poem about how much you love SQL', 2,
-      columns = {'index': 'INT','message': 'VARCHAR', 'message_role': 'VARCHAR', 'finish_reason': 'VARCHAR'},
-    );
+    SELECT * FROM pytable('ducktables.openai:prompt', 'Write a limerick poem about how much you love SQL', 2);
     """
     completion = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",

--- a/pythonpkgs/ducktables/tests/ducktables/test_github.py
+++ b/pythonpkgs/ducktables/tests/ducktables/test_github.py
@@ -1,0 +1,16 @@
+
+from unittest import TestCase
+from ducktables import github
+
+
+class TestGithub(TestCase):
+    def test_schema(self):
+        # @ducktable(name = str, description = str, language = str)
+        actual_names = github.repos_for.column_names()
+        expected_names = ('name', 'description', 'language')
+        self.assertEqual(expected_names, actual_names)
+
+        actual_types = github.repos_for.column_types()
+        expected_types = (str, str, str)
+        self.assertEqual(expected_types, actual_types)
+

--- a/pythonpkgs/ducktables/tests/ducktables/test_github.py
+++ b/pythonpkgs/ducktables/tests/ducktables/test_github.py
@@ -7,7 +7,7 @@ class TestGithub(TestCase):
     def test_schema(self):
         # @ducktable(name = str, description = str, language = str)
         actual_names = github.repos_for.column_names()
-        expected_names = ('name', 'description', 'language')
+        expected_names = ('repo', 'description', 'language')
         self.assertEqual(expected_names, actual_names)
 
         actual_types = github.repos_for.column_types()

--- a/pythonpkgs/ducktables/tests/ducktables/test_init.py
+++ b/pythonpkgs/ducktables/tests/ducktables/test_init.py
@@ -94,3 +94,67 @@ class TestDuckTableSchemaWrapper(TestCase):
         actual_columns = some_types.column_types()
         expected_columns = None
         self.assertEqual(expected_columns, actual_columns)
+
+    def test_explicit_names_with_annotation(self):
+        @ducktable('index', 'charval')
+        def some_types(input) -> Iterator[Tuple[int, str]]:
+            return index_chars(input)
+
+        actual_types = some_types.column_types()
+        expected_types = [int, str]
+        self.assertEqual(expected_types, actual_types)
+
+        actual_names = some_types.column_names()
+        expected_names = ('index', 'charval')
+        self.assertEqual(expected_names, actual_names)
+
+        rows = list(some_types('foo'))
+        expected_rows = [
+            (0, 'f'),
+            (1, 'o'),
+            (2, 'o'),
+            ]
+        self.assertEqual(rows, expected_rows)
+
+    def test_explicit_names_and_types(self):
+        @ducktable(index = int, charval = str)
+        def some_types(input):
+            return index_chars(input)
+
+        actual_types = some_types.column_types()
+        expected_types = (int, str)
+        self.assertEqual(expected_types, actual_types)
+
+        actual_names = some_types.column_names()
+        expected_names = ('index', 'charval')
+        self.assertEqual(expected_names, actual_names)
+
+        rows = list(some_types('foo'))
+        expected_rows = [
+            (0, 'f'),
+            (1, 'o'),
+            (2, 'o'),
+            ]
+        self.assertEqual(rows, expected_rows)
+
+    def test_explicit_names_and_types_overrides_type_annotation(self):
+        """If the user supplies type as decorator args, we ignore the annotation"""
+        @ducktable(index = int, charval = str)
+        def some_types(input) -> Iterator[Tuple[str, str, int, str]]:
+            return index_chars(input)
+
+        actual_types = some_types.column_types()
+        expected_types = (int, str)
+        self.assertEqual(expected_types, actual_types)
+
+        actual_names = some_types.column_names()
+        expected_names = ('index', 'charval')
+        self.assertEqual(expected_names, actual_names)
+
+        rows = list(some_types('foo'))
+        expected_rows = [
+            (0, 'f'),
+            (1, 'o'),
+            (2, 'o'),
+            ]
+        self.assertEqual(rows, expected_rows)

--- a/pythonpkgs/ducktables/tests/ducktables/test_openai.py
+++ b/pythonpkgs/ducktables/tests/ducktables/test_openai.py
@@ -1,3 +1,18 @@
 
 
 from ducktables import openai
+from unittest import TestCase
+
+
+class TestOpenAI(TestCase):
+
+    def test_prompt_column_types(self):
+        expected = (int, str, str, str)
+        actual = openai.prompt.column_types()
+        self.assertEqual(expected, actual)
+
+    def test_prompt_column_names(self):
+        expected = ('index', 'message', 'message_role', 'finish_reason')
+        actual = openai.prompt.column_names()
+        self.assertEqual(expected, actual)
+        

--- a/scripts/python-ci.sh
+++ b/scripts/python-ci.sh
@@ -5,12 +5,16 @@ set -e;
 echo "Entering python land..."
 cd pythonpkgs/
 
+if [ -z "$PYTHON_VERSION" ]; then
+    PYTHON_VERSION=3.8;
+fi
+
 echo "Checking that we have a python..."
-which python3.8
+which python$PYTHON_VERSION
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python3.8 -m venv myenv
+python$PYTHON_VERSION -m venv myenv
 echo "Sourcing the env"
 source myenv/bin/activate
 

--- a/scripts/python-ci.sh
+++ b/scripts/python-ci.sh
@@ -14,9 +14,9 @@ which python$PYTHON_VERSION
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python$PYTHON_VERSION -m venv myenv
+python$PYTHON_VERSION -m venv env-py$PYTHON_VERSION
 echo "Sourcing the env"
-source myenv/bin/activate
+source env-py$PYTHON_VERSION/bin/activate
 
 cd ducktables;
 

--- a/scripts/python-release.sh
+++ b/scripts/python-release.sh
@@ -10,9 +10,9 @@ which python3.8
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python3.8 -m venv myenv
+python3.8 -m venv env-py3.8
 echo "Sourcing the env"
-source myenv/bin/activate
+source env-py3.8/bin/activate
 
 cd ducktables;
 

--- a/scripts/python-test-integration.sh
+++ b/scripts/python-test-integration.sh
@@ -19,9 +19,9 @@ which python$PYTHON_VERSION
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python$PYTHON_VERSION -m venv myenv
+python$PYTHON_VERSION -m venv env-py$PYTHON_VERSION
 echo "Sourcing the env"
-source myenv/bin/activate
+source env-py$PYTHON_VERSION/bin/activate
 
 cd ducktables;
 

--- a/scripts/python-test-integration.sh
+++ b/scripts/python-test-integration.sh
@@ -11,6 +11,10 @@ if [ -z "$PYTHON_VERSION" ]; then
     PYTHON_VERSION=3.8;
 fi
 
+if [ -z "$BUILD_TARGET" ]; then
+    BUILD_TARGET=release
+fi
+
 echo "Entering python land..."
 cd pythonpkgs/
 
@@ -36,4 +40,4 @@ pip install -r requirements.txt
 cd ../../
 
 export PYTHONPATH=pythonpkgs/ducktables
-./build/release/test/unittest --test-dir . "[ducktables-integration]"
+./build/$BUILD_TARGET/test/unittest --test-dir . "[ducktables-integration]"

--- a/scripts/python-test-integration.sh
+++ b/scripts/python-test-integration.sh
@@ -6,16 +6,20 @@ if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
    echo "Please specify a path to your Google credentials file via GOOGLE_APPLICATION_CREDENTIALS";
    exit 1;
 fi
-   
+
+if [ -z "$PYTHON_VERSION" ]; then
+    PYTHON_VERSION=3.8;
+fi
+
 echo "Entering python land..."
 cd pythonpkgs/
 
 echo "Checking that we have a python..."
-which python3.8
+which python$PYTHON_VERSION
 
 # Create a virtual environment
 echo "Creating our virtual environment"
-python3.8 -m venv myenv
+python$PYTHON_VERSION -m venv myenv
 echo "Sourcing the env"
 source myenv/bin/activate
 

--- a/src/cpy/exception.cpp
+++ b/src/cpy/exception.cpp
@@ -1,0 +1,74 @@
+
+
+#include <string>
+#include <Python.h>
+#include <stdexcept>
+#include <cpy/object.hpp>
+#include <cpy/exception.hpp>
+
+namespace cpy {
+std::string Exception::message() const {
+	return _message;
+}
+
+std::string Exception::traceback() const {
+	return _traceback;
+}
+
+// copy
+Exception::Exception(const Exception &other)
+    : Exception(other.pytype, other.pymessage, other.pytraceback, other._type, other._message, other._traceback) {
+}
+
+// move
+Exception::Exception(Exception &&other)
+    : Exception(other.pytype, other.pymessage, other.pytraceback, other._type, other._message, other._traceback) {
+}
+
+// copy assignment
+Exception &Exception::operator=(const Exception &other) {
+	pytype = other.pytype;
+	pymessage = other.pymessage;
+	pytraceback = other.pytraceback;
+	_type = other._type;
+	_message = other._message;
+	_traceback = other._traceback;
+	return *this;
+}
+
+Exception::Exception(cpy::Object pytype, cpy::Object pymessage, cpy::Object pytraceback, std::string _type,
+                     std::string _message, std::string _traceback)
+    : pytype(pytype), pymessage(pymessage), pytraceback(pytraceback), _type(_type), _message(_message),
+      _traceback(_traceback) {
+}
+
+Exception::Exception() {
+	if (!PyErr_Occurred()) {
+		throw std::runtime_error("Attempt create exception object w/o underlying Python exception");
+	}
+
+	PyObject *po_type, *po_value, *po_traceback;
+	PyErr_Fetch(&po_type, &po_value, &po_traceback);
+
+	if (po_type) {
+		pytype = cpy::Object(po_type, true);
+	}
+	if (po_value) {
+		pymessage = cpy::Object(po_value, true);
+	}
+	if (po_traceback) {
+		// pytraceback = cpy::Object(po_traceback, true);
+	}
+
+	if (!pytype.isempty()) {
+		_type = pytype.str();
+	}
+	if (!pymessage.isempty()) {
+		_message = pymessage.str();
+	}
+	if (!pytraceback.isempty()) {
+		_traceback = pytraceback.str();
+	}
+	PyErr_Clear();
+}
+} // namespace cpy

--- a/src/cpy/function.cpp
+++ b/src/cpy/function.cpp
@@ -1,0 +1,20 @@
+
+#include <Python.h>
+#include <stdexcept>
+#include <cpy/module.hpp>
+#include <cpy/function.hpp>
+
+namespace cpy {
+cpy::Function import(const std::string &module_name, const std::string &function_name) {
+	auto module = cpy::Module(module_name);
+	cpy::Object func = module.attr(function_name);
+	if (!func.callable()) {
+		throw std::runtime_error("Attribute found in module, but it is not callable");
+	} else {
+		cpy::Function funcObj(func.getpy(), true);
+		return funcObj;
+	}
+}
+Function::Function(cpy::Object src) : cpy::Object(src.getpy(), true) {
+}
+} // namespace cpy

--- a/src/cpy/module.cpp
+++ b/src/cpy/module.cpp
@@ -8,16 +8,6 @@ namespace cpy {
     module_name_ = module_name;
   }
 
-  cpy::Object Module::getattr(const std::string &attribute_name) {
-    PyObject *attr = PyObject_GetAttrString(obj, attribute_name.c_str());
-    if(!attr) {
-      // todo: check if no such attribute, or some other error.
-      throw std::runtime_error("Failed to access attribute: " + attribute_name);
-    } else {
-      return cpy::Object(attr);
-    }
-  }
-
   PyObject* Module::doImport(const std::string &module_name) {
     auto obj = PyImport_ImportModule(module_name.c_str());
     if (!obj) {

--- a/src/cpy/module.cpp
+++ b/src/cpy/module.cpp
@@ -4,19 +4,19 @@
 #include <cpy/module.hpp>
 
 namespace cpy {
-  Module::Module(const std::string &module_name) : cpy::Object(doImport(module_name), true) {
-    module_name_ = module_name;
-  }
+Module::Module(const std::string &module_name) : cpy::Object(doImport(module_name), true) {
+	module_name_ = module_name;
+}
 
-  PyObject* Module::doImport(const std::string &module_name) {
-    auto obj = PyImport_ImportModule(module_name.c_str());
-    if (!obj) {
-      // PyErr_Print();
-      // todo: Throw an exception class that gives access to the Python error
-      throw std::runtime_error("Failed to import module: " + module_name);
-    } else {
-      return obj;
-    }  
-  }
+PyObject *Module::doImport(const std::string &module_name) {
+	auto obj = PyImport_ImportModule(module_name.c_str());
+	if (!obj) {
+		// PyErr_Print();
+		// todo: Throw an exception class that gives access to the Python error
+		throw std::runtime_error("Failed to import module: " + module_name);
+	} else {
+		return obj;
+	}
+}
 
 } // namespace cpy

--- a/src/cpy/module.cpp
+++ b/src/cpy/module.cpp
@@ -1,0 +1,32 @@
+
+#include <Python.h>
+#include <stdexcept>
+#include <cpy/module.hpp>
+
+namespace cpy {
+  Module::Module(const std::string &module_name) : cpy::Object(doImport(module_name), true) {
+    module_name_ = module_name;
+  }
+
+  cpy::Object Module::getattr(const std::string &attribute_name) {
+    PyObject *attr = PyObject_GetAttrString(obj, attribute_name.c_str());
+    if(!attr) {
+      // todo: check if no such attribute, or some other error.
+      throw std::runtime_error("Failed to access attribute: " + attribute_name);
+    } else {
+      return cpy::Object(attr);
+    }
+  }
+
+  PyObject* Module::doImport(const std::string &module_name) {
+    auto obj = PyImport_ImportModule(module_name.c_str());
+    if (!obj) {
+      // PyErr_Print();
+      // todo: Throw an exception class that gives access to the Python error
+      throw std::runtime_error("Failed to import module: " + module_name);
+    } else {
+      return obj;
+    }  
+  }
+
+} // namespace cpy

--- a/src/cpy/object.cpp
+++ b/src/cpy/object.cpp
@@ -5,166 +5,166 @@
 #include <cpy/exception.hpp>
 
 namespace cpy {
-  cpy::Object list(cpy::Object src) {
-    auto pysrc = src.getpy();
-    PyObject* pylist = PySequence_List(pysrc);
-    Py_DECREF(pysrc);
-    if(!pylist) {
-      throw std::runtime_error("Failed to convert to list");
-    } else {
-      cpy::Object list(pylist, true);
-      return list;
-    }
-  }
-  
-  PyObject* Object::getpy() {
-    Py_XINCREF(obj);
-    return obj;
-  }
+cpy::Object list(cpy::Object src) {
+	auto pysrc = src.getpy();
+	PyObject *pylist = PySequence_List(pysrc);
+	Py_DECREF(pysrc);
+	if (!pylist) {
+		throw std::runtime_error("Failed to convert to list");
+	} else {
+		cpy::Object list(pylist, true);
+		return list;
+	}
+}
 
-  Object::Object() {
-    obj = nullptr;
-  }
-  
-  Object::Object(PyObject *obj) : obj(obj) {
-    Py_XINCREF(obj);
-  }
+PyObject *Object::getpy() {
+	Py_XINCREF(obj);
+	return obj;
+}
 
-  Object::Object(PyObject* obj, bool assumeOwnership) : obj(obj) {
-    if(!assumeOwnership) {
-      Py_INCREF(obj);
-    }
-  }
-  
-  Object::~Object() {
-    Py_XDECREF(obj);
-    obj = nullptr;
-  }
+Object::Object() {
+	obj = nullptr;
+}
 
-  // copy
-  Object::Object(const Object &other) : obj(other.obj) {
-    Py_XINCREF(obj);
-  }
+Object::Object(PyObject *obj) : obj(obj) {
+	Py_XINCREF(obj);
+}
 
-  // Move
-  Object::Object(Object &&other) : obj(other.obj) {
-    other.obj = nullptr;
-  }
+Object::Object(PyObject *obj, bool assumeOwnership) : obj(obj) {
+	if (!assumeOwnership) {
+		Py_INCREF(obj);
+	}
+}
 
-  Object& Object::operator=(const Object& other) {
-    Py_XINCREF(obj);
-    obj = other.obj;
-    return *this;
-  }
-  
-  cpy::Object Object::attr(const std::string &attribute_name) {
-    PyObject *attr = PyObject_GetAttrString(obj, attribute_name.c_str());
-    if(!attr) {
-      // todo: check if no such attribute, or some other error.
-      throw std::runtime_error("Failed to access attribute: " + attribute_name);
-    } else {
-      return cpy::Object(attr);
-    }
-  }
+Object::~Object() {
+	Py_XDECREF(obj);
+	obj = nullptr;
+}
 
-  bool Object::isinstance(cpy::Object cls) {
-    PyObject* clsptr = cls.getpy();
-    bool is_cls = isinstance(clsptr);
-    Py_XDECREF(clsptr);
-    return is_cls;
-  }
+// copy
+Object::Object(const Object &other) : obj(other.obj) {
+	Py_XINCREF(obj);
+}
 
-  bool Object::isinstance(PyObject* cls) {
-    int is_cls = PyObject_IsInstance(obj, cls);
-    return is_cls;
-  }
+// Move
+Object::Object(Object &&other) : obj(other.obj) {
+	other.obj = nullptr;
+}
 
-  bool Object::isempty() {
-    return (nullptr == obj);
-  }
+Object &Object::operator=(const Object &other) {
+	Py_XINCREF(obj);
+	obj = other.obj;
+	return *this;
+}
 
-  bool Object::isnone() {
-    return (Py_None == obj);
-  }
-  
-  bool Object::callable() {
-    return PyCallable_Check(obj);
-  }
+cpy::Object Object::attr(const std::string &attribute_name) {
+	PyObject *attr = PyObject_GetAttrString(obj, attribute_name.c_str());
+	if (!attr) {
+		// todo: check if no such attribute, or some other error.
+		throw std::runtime_error("Failed to access attribute: " + attribute_name);
+	} else {
+		return cpy::Object(attr);
+	}
+}
 
-  cpy::Object Object::call(cpy::Object args) const {
-    auto pyargs = args.getpy();
-    PyObject *result = PyObject_CallObject(obj, pyargs);
-    Py_XDECREF(pyargs);
+bool Object::isinstance(cpy::Object cls) {
+	PyObject *clsptr = cls.getpy();
+	bool is_cls = isinstance(clsptr);
+	Py_XDECREF(clsptr);
+	return is_cls;
+}
 
-    if(PyErr_Occurred()) {
-      throw cpy::Exception();
-    } else if(!result) {
-      throw std::runtime_error("Error calling function");
-    } else {
-      return cpy::Object(result, true);
-    }
-  }
+bool Object::isinstance(PyObject *cls) {
+	int is_cls = PyObject_IsInstance(obj, cls);
+	return is_cls;
+}
 
-  cpy::Object Object::call(cpy::Object args, cpy::Object kwargs) const {
-    auto pyargs = args.getpy();
-    auto pykwargs = kwargs.getpy();
-    PyObject *result = PyObject_Call(obj, pyargs, pykwargs);
-    Py_XDECREF(pyargs);
-    Py_XDECREF(pykwargs);
-    if(PyErr_Occurred()) {
-      throw cpy::Exception();
-    } else if(!result) {
-      throw std::runtime_error("Error calling function");
-    } else {
-      return cpy::Object(result, true);
-    }
-  }
+bool Object::isempty() {
+	return (nullptr == obj);
+}
 
-  cpy::Object Object::call(PyObject* pyargs) const {
-    auto args = cpy::Object(pyargs);
-    return call(args);
-  }
+bool Object::isnone() {
+	return (Py_None == obj);
+}
 
-  cpy::Object Object::call(PyObject* pyargs, PyObject* pykwargs) const {
-    auto args = cpy::Object(pyargs);
-    auto kwargs = cpy::Object(pykwargs);
-    return call(args, kwargs);
-  }
+bool Object::callable() {
+	return PyCallable_Check(obj);
+}
 
-  cpy::Object Object::iter() {
-    PyObject *py_iter = PyObject_GetIter(obj);
-    if(!py_iter) {
-      // todo: include python error
-      throw std::runtime_error("Failed to convert to an iterator");
-    } else {
-      cpy::Object itrobj(py_iter);
-      Py_DECREF(py_iter);
-      return itrobj;
-    }
-  }
+cpy::Object Object::call(cpy::Object args) const {
+	auto pyargs = args.getpy();
+	PyObject *result = PyObject_CallObject(obj, pyargs);
+	Py_XDECREF(pyargs);
 
-  std::string Object::str() {
-    if(isempty()) {
-      throw std::runtime_error("Attempt to convert a nullptr to a string");
-    }
-    PyObject* py_value_str = PyObject_Str(obj);
-    if(!py_value_str) {
-      throw std::runtime_error("Failed to convert to a python string");
-    }
-    PyObject* py_value_unicode = PyUnicode_AsUTF8String(py_value_str);
-    if(!py_value_unicode) {
-      Py_DECREF(py_value_str);
-      throw std::runtime_error("Failed to convert python string to unicode");
-    }
-    char* str = PyBytes_AsString(py_value_unicode);
-    if(!str) {
-      Py_DECREF(py_value_unicode);
-      Py_DECREF(py_value_str);
-      throw std::runtime_error("Failed to convert python unicode to c++ string");
-    }
-    Py_DECREF(py_value_unicode);
-    Py_DECREF(py_value_str);
-    return str;
-  }
-  
+	if (PyErr_Occurred()) {
+		throw cpy::Exception();
+	} else if (!result) {
+		throw std::runtime_error("Error calling function");
+	} else {
+		return cpy::Object(result, true);
+	}
+}
+
+cpy::Object Object::call(cpy::Object args, cpy::Object kwargs) const {
+	auto pyargs = args.getpy();
+	auto pykwargs = kwargs.getpy();
+	PyObject *result = PyObject_Call(obj, pyargs, pykwargs);
+	Py_XDECREF(pyargs);
+	Py_XDECREF(pykwargs);
+	if (PyErr_Occurred()) {
+		throw cpy::Exception();
+	} else if (!result) {
+		throw std::runtime_error("Error calling function");
+	} else {
+		return cpy::Object(result, true);
+	}
+}
+
+cpy::Object Object::call(PyObject *pyargs) const {
+	auto args = cpy::Object(pyargs);
+	return call(args);
+}
+
+cpy::Object Object::call(PyObject *pyargs, PyObject *pykwargs) const {
+	auto args = cpy::Object(pyargs);
+	auto kwargs = cpy::Object(pykwargs);
+	return call(args, kwargs);
+}
+
+cpy::Object Object::iter() {
+	PyObject *py_iter = PyObject_GetIter(obj);
+	if (!py_iter) {
+		// todo: include python error
+		throw std::runtime_error("Failed to convert to an iterator");
+	} else {
+		cpy::Object itrobj(py_iter);
+		Py_DECREF(py_iter);
+		return itrobj;
+	}
+}
+
+std::string Object::str() {
+	if (isempty()) {
+		throw std::runtime_error("Attempt to convert a nullptr to a string");
+	}
+	PyObject *py_value_str = PyObject_Str(obj);
+	if (!py_value_str) {
+		throw std::runtime_error("Failed to convert to a python string");
+	}
+	PyObject *py_value_unicode = PyUnicode_AsUTF8String(py_value_str);
+	if (!py_value_unicode) {
+		Py_DECREF(py_value_str);
+		throw std::runtime_error("Failed to convert python string to unicode");
+	}
+	char *str = PyBytes_AsString(py_value_unicode);
+	if (!str) {
+		Py_DECREF(py_value_unicode);
+		Py_DECREF(py_value_str);
+		throw std::runtime_error("Failed to convert python unicode to c++ string");
+	}
+	Py_DECREF(py_value_unicode);
+	Py_DECREF(py_value_str);
+	return str;
+}
+
 } // namespace cpy

--- a/src/cpy/object.cpp
+++ b/src/cpy/object.cpp
@@ -2,16 +2,32 @@
 #include <Python.h>
 #include <stdexcept>
 #include <cpy/object.hpp>
+#include <cpy/exception.hpp>
 
 namespace cpy {
-
+  cpy::Object list(cpy::Object src) {
+    auto pysrc = src.getpy();
+    PyObject* pylist = PySequence_List(pysrc);
+    Py_DECREF(pysrc);
+    if(!pylist) {
+      throw std::runtime_error("Failed to convert to list");
+    } else {
+      cpy::Object list(pylist, true);
+      return list;
+    }
+  }
+  
   PyObject* Object::getpy() {
-    Py_INCREF(obj);
+    Py_XINCREF(obj);
     return obj;
+  }
+
+  Object::Object() {
+    obj = nullptr;
   }
   
   Object::Object(PyObject *obj) : obj(obj) {
-    Py_INCREF(obj);
+    Py_XINCREF(obj);
   }
 
   Object::Object(PyObject* obj, bool assumeOwnership) : obj(obj) {
@@ -21,14 +37,13 @@ namespace cpy {
   }
   
   Object::~Object() {
-    if(obj) {
-      Py_DECREF(obj);
-    }
+    Py_XDECREF(obj);
+    obj = nullptr;
   }
 
   // copy
   Object::Object(const Object &other) : obj(other.obj) {
-    Py_INCREF(obj);
+    Py_XINCREF(obj);
   }
 
   // Move
@@ -36,10 +51,26 @@ namespace cpy {
     other.obj = nullptr;
   }
 
+  Object& Object::operator=(const Object& other) {
+    Py_XINCREF(obj);
+    obj = other.obj;
+    return *this;
+  }
+  
+  cpy::Object Object::attr(const std::string &attribute_name) {
+    PyObject *attr = PyObject_GetAttrString(obj, attribute_name.c_str());
+    if(!attr) {
+      // todo: check if no such attribute, or some other error.
+      throw std::runtime_error("Failed to access attribute: " + attribute_name);
+    } else {
+      return cpy::Object(attr);
+    }
+  }
+
   bool Object::isinstance(cpy::Object cls) {
     PyObject* clsptr = cls.getpy();
     bool is_cls = isinstance(clsptr);
-    Py_DECREF(clsptr);
+    Py_XDECREF(clsptr);
     return is_cls;
   }
 
@@ -47,7 +78,59 @@ namespace cpy {
     int is_cls = PyObject_IsInstance(obj, cls);
     return is_cls;
   }
+
+  bool Object::isempty() {
+    return (nullptr == obj);
+  }
+
+  bool Object::isnone() {
+    return (Py_None == obj);
+  }
   
+  bool Object::callable() {
+    return PyCallable_Check(obj);
+  }
+
+  cpy::Object Object::call(cpy::Object args) const {
+    auto pyargs = args.getpy();
+    PyObject *result = PyObject_CallObject(obj, pyargs);
+    Py_XDECREF(pyargs);
+
+    if(PyErr_Occurred()) {
+      throw cpy::Exception();
+    } else if(!result) {
+      throw std::runtime_error("Error calling function");
+    } else {
+      return cpy::Object(result, true);
+    }
+  }
+
+  cpy::Object Object::call(cpy::Object args, cpy::Object kwargs) const {
+    auto pyargs = args.getpy();
+    auto pykwargs = kwargs.getpy();
+    PyObject *result = PyObject_Call(obj, pyargs, pykwargs);
+    Py_XDECREF(pyargs);
+    Py_XDECREF(pykwargs);
+    if(PyErr_Occurred()) {
+      throw cpy::Exception();
+    } else if(!result) {
+      throw std::runtime_error("Error calling function");
+    } else {
+      return cpy::Object(result, true);
+    }
+  }
+
+  cpy::Object Object::call(PyObject* pyargs) const {
+    auto args = cpy::Object(pyargs);
+    return call(args);
+  }
+
+  cpy::Object Object::call(PyObject* pyargs, PyObject* pykwargs) const {
+    auto args = cpy::Object(pyargs);
+    auto kwargs = cpy::Object(pykwargs);
+    return call(args, kwargs);
+  }
+
   cpy::Object Object::iter() {
     PyObject *py_iter = PyObject_GetIter(obj);
     if(!py_iter) {
@@ -59,4 +142,29 @@ namespace cpy {
       return itrobj;
     }
   }
+
+  std::string Object::str() {
+    if(isempty()) {
+      throw std::runtime_error("Attempt to convert a nullptr to a string");
+    }
+    PyObject* py_value_str = PyObject_Str(obj);
+    if(!py_value_str) {
+      throw std::runtime_error("Failed to convert to a python string");
+    }
+    PyObject* py_value_unicode = PyUnicode_AsUTF8String(py_value_str);
+    if(!py_value_unicode) {
+      Py_DECREF(py_value_str);
+      throw std::runtime_error("Failed to convert python string to unicode");
+    }
+    char* str = PyBytes_AsString(py_value_unicode);
+    if(!str) {
+      Py_DECREF(py_value_unicode);
+      Py_DECREF(py_value_str);
+      throw std::runtime_error("Failed to convert python unicode to c++ string");
+    }
+    Py_DECREF(py_value_unicode);
+    Py_DECREF(py_value_str);
+    return str;
+  }
+  
 } // namespace cpy

--- a/src/cpy/object.cpp
+++ b/src/cpy/object.cpp
@@ -1,0 +1,62 @@
+
+#include <Python.h>
+#include <stdexcept>
+#include <cpy/object.hpp>
+
+namespace cpy {
+
+  PyObject* Object::getpy() {
+    Py_INCREF(obj);
+    return obj;
+  }
+  
+  Object::Object(PyObject *obj) : obj(obj) {
+    Py_INCREF(obj);
+  }
+
+  Object::Object(PyObject* obj, bool assumeOwnership) : obj(obj) {
+    if(!assumeOwnership) {
+      Py_INCREF(obj);
+    }
+  }
+  
+  Object::~Object() {
+    if(obj) {
+      Py_DECREF(obj);
+    }
+  }
+
+  // copy
+  Object::Object(const Object &other) : obj(other.obj) {
+    Py_INCREF(obj);
+  }
+
+  // Move
+  Object::Object(Object &&other) : obj(other.obj) {
+    other.obj = nullptr;
+  }
+
+  bool Object::isinstance(cpy::Object cls) {
+    PyObject* clsptr = cls.getpy();
+    bool is_cls = isinstance(clsptr);
+    Py_DECREF(clsptr);
+    return is_cls;
+  }
+
+  bool Object::isinstance(PyObject* cls) {
+    int is_cls = PyObject_IsInstance(obj, cls);
+    return is_cls;
+  }
+  
+  cpy::Object Object::iter() {
+    PyObject *py_iter = PyObject_GetIter(obj);
+    if(!py_iter) {
+      // todo: include python error
+      throw std::runtime_error("Failed to convert to an iterator");
+    } else {
+      cpy::Object itrobj(py_iter);
+      Py_DECREF(py_iter);
+      return itrobj;
+    }
+  }
+} // namespace cpy

--- a/src/include/cpy.hpp
+++ b/src/include/cpy.hpp
@@ -1,0 +1,8 @@
+#ifndef CPY_HPP
+#define CPY_HPP
+
+#include <cpy/object.hpp>
+#include <cpy/module.hpp>
+#include <cpy/function.hpp>
+
+#endif // CPY_HPP

--- a/src/include/cpy/exception.hpp
+++ b/src/include/cpy/exception.hpp
@@ -1,0 +1,35 @@
+
+#ifndef CPY_EXCEPTION_HPP
+#define CPY_EXCEPTION_HPP
+
+#include <string>
+#include <Python.h>
+#include <cpy/object.hpp>
+
+namespace cpy {
+class Exception {
+
+public:
+	Exception();
+	Exception(cpy::Object pytype, cpy::Object pymessage, cpy::Object pytraceback, std::string _type,
+	          std::string _message, std::string _traceback);
+
+	Exception(const Exception &);                 // copy
+	Exception(Exception &&);                      // move
+	Exception &operator=(const Exception &other); // copy assignment
+
+	std::string message() const;
+	std::string traceback() const;
+
+private:
+	cpy::Object pytype;
+	cpy::Object pymessage;
+	cpy::Object pytraceback;
+
+	std::string _type;
+	std::string _message;
+	std::string _traceback;
+};
+
+} // namespace cpy
+#endif // CPY_MODULE_HPP

--- a/src/include/cpy/function.hpp
+++ b/src/include/cpy/function.hpp
@@ -1,0 +1,17 @@
+
+
+#ifndef CPY_FUNCTION_HPP
+#define CPY_FUNCTION_HPP
+
+#include <Python.h>
+#include <cpy/object.hpp>
+
+namespace cpy {
+class Function : public cpy::Object {
+public:
+	using cpy::Object::Object;
+	Function(cpy::Object src);
+};
+cpy::Function import(const std::string &module_name, const std::string &function_name);
+} // namespace cpy
+#endif // CPY_FUNCTION_HPP

--- a/src/include/cpy/module.hpp
+++ b/src/include/cpy/module.hpp
@@ -7,15 +7,15 @@
 #include <cpy/object.hpp>
 
 namespace cpy {
-  class Module : public cpy::Object {
+class Module : public cpy::Object {
 
-  public:
-    Module(const std::string &module_name);
+public:
+	Module(const std::string &module_name);
 
-  private:
-    std::string module_name_;
-    static PyObject* doImport(const std::string &module_name);
-  };
+private:
+	std::string module_name_;
+	static PyObject *doImport(const std::string &module_name);
+};
 
 } // namespace cpy
-# endif // CPY_MODULE_HPP
+#endif // CPY_MODULE_HPP

--- a/src/include/cpy/module.hpp
+++ b/src/include/cpy/module.hpp
@@ -1,4 +1,7 @@
 
+#ifndef CPY_MODULE_HPP
+#define CPY_MODULE_HPP
+
 #include <string>
 #include <Python.h>
 #include <cpy/object.hpp>
@@ -8,7 +11,6 @@ namespace cpy {
 
   public:
     Module(const std::string &module_name);
-    cpy::Object getattr(const std::string &attribute_name);
 
   private:
     std::string module_name_;
@@ -16,3 +18,4 @@ namespace cpy {
   };
 
 } // namespace cpy
+# endif // CPY_MODULE_HPP

--- a/src/include/cpy/module.hpp
+++ b/src/include/cpy/module.hpp
@@ -1,0 +1,18 @@
+
+#include <string>
+#include <Python.h>
+#include <cpy/object.hpp>
+
+namespace cpy {
+  class Module : public cpy::Object {
+
+  public:
+    Module(const std::string &module_name);
+    cpy::Object getattr(const std::string &attribute_name);
+
+  private:
+    std::string module_name_;
+    static PyObject* doImport(const std::string &module_name);
+  };
+
+} // namespace cpy

--- a/src/include/cpy/object.hpp
+++ b/src/include/cpy/object.hpp
@@ -1,18 +1,43 @@
+
+#ifndef CPY_OBJECT_HPP
+#define CPY_OBJECT_HPP
+
 #include <Python.h>
 
-namespace cpy {
+namespace cpy {  
   class Object {
   public:
+    Object();
     Object(PyObject *obj);
     Object(PyObject *obj, bool assumeOwnership);
     ~Object();
     Object(const Object&); // copy
     Object(Object&&); // move
+    Object& operator=(const Object& other); // copy assignment
+    
+    /* Grab the pointer to the underlying python object, increments its reference count */
     PyObject* getpy();
+    
+    cpy::Object attr(const std::string &attribute_name);
     bool isinstance(cpy::Object cls);
     bool isinstance(PyObject* cls);
+    bool isempty();
+    bool isnone();
+    
+    bool callable();
+    cpy::Object call(cpy::Object args) const;
+    cpy::Object call(cpy::Object args, cpy::Object kwargs) const;
+    cpy::Object call(PyObject* pyargs) const;
+    cpy::Object call(PyObject* pyargs, PyObject* pykwargs) const;
+
     cpy::Object iter();
+
+    std::string str();
   protected:
     PyObject *obj;
   };
+
+  cpy::Object list(cpy::Object src);
 } // namespace cpy
+# endif // CPY_OBJECT_HPP
+

--- a/src/include/cpy/object.hpp
+++ b/src/include/cpy/object.hpp
@@ -4,40 +4,40 @@
 
 #include <Python.h>
 
-namespace cpy {  
-  class Object {
-  public:
-    Object();
-    Object(PyObject *obj);
-    Object(PyObject *obj, bool assumeOwnership);
-    ~Object();
-    Object(const Object&); // copy
-    Object(Object&&); // move
-    Object& operator=(const Object& other); // copy assignment
-    
-    /* Grab the pointer to the underlying python object, increments its reference count */
-    PyObject* getpy();
-    
-    cpy::Object attr(const std::string &attribute_name);
-    bool isinstance(cpy::Object cls);
-    bool isinstance(PyObject* cls);
-    bool isempty();
-    bool isnone();
-    
-    bool callable();
-    cpy::Object call(cpy::Object args) const;
-    cpy::Object call(cpy::Object args, cpy::Object kwargs) const;
-    cpy::Object call(PyObject* pyargs) const;
-    cpy::Object call(PyObject* pyargs, PyObject* pykwargs) const;
+namespace cpy {
+class Object {
+public:
+	Object();
+	Object(PyObject *obj);
+	Object(PyObject *obj, bool assumeOwnership);
+	~Object();
+	Object(const Object &);                 // copy
+	Object(Object &&);                      // move
+	Object &operator=(const Object &other); // copy assignment
 
-    cpy::Object iter();
+	/* Grab the pointer to the underlying python object, increments its reference count */
+	PyObject *getpy();
 
-    std::string str();
-  protected:
-    PyObject *obj;
-  };
+	cpy::Object attr(const std::string &attribute_name);
+	bool isinstance(cpy::Object cls);
+	bool isinstance(PyObject *cls);
+	bool isempty();
+	bool isnone();
 
-  cpy::Object list(cpy::Object src);
+	bool callable();
+	cpy::Object call(cpy::Object args) const;
+	cpy::Object call(cpy::Object args, cpy::Object kwargs) const;
+	cpy::Object call(PyObject *pyargs) const;
+	cpy::Object call(PyObject *pyargs, PyObject *pykwargs) const;
+
+	cpy::Object iter();
+
+	std::string str();
+
+protected:
+	PyObject *obj;
+};
+
+cpy::Object list(cpy::Object src);
 } // namespace cpy
-# endif // CPY_OBJECT_HPP
-
+#endif // CPY_OBJECT_HPP

--- a/src/include/cpy/object.hpp
+++ b/src/include/cpy/object.hpp
@@ -1,0 +1,18 @@
+#include <Python.h>
+
+namespace cpy {
+  class Object {
+  public:
+    Object(PyObject *obj);
+    Object(PyObject *obj, bool assumeOwnership);
+    ~Object();
+    Object(const Object&); // copy
+    Object(Object&&); // move
+    PyObject* getpy();
+    bool isinstance(cpy::Object cls);
+    bool isinstance(PyObject* cls);
+    cpy::Object iter();
+  protected:
+    PyObject *obj;
+  };
+} // namespace cpy

--- a/src/include/pyconvert.hpp
+++ b/src/include/pyconvert.hpp
@@ -16,4 +16,7 @@ std::vector<duckdb::LogicalType> PyTypesToLogicalTypes(const std::vector<PyObjec
 // Duplicates functionality of PyUnicode_AsUTF8() which is not part of the limited ABI
 char *Unicode_AsUTF8(PyObject *unicodeObject);
 
+// Wrapper around isinstance(), similar to the PyObject_IsInstance() function that isn't
+// part of the limited ABI.
+bool PyIsInstance(PyObject *instance, PyObject *classObj);
 } // namespace pyudf

--- a/src/include/python_table_function.hpp
+++ b/src/include/python_table_function.hpp
@@ -16,8 +16,11 @@ public:
 
 private:
 	std::vector<PyObject *> pycolumn_types(PyObject *args, PyObject *kwargs);
+	std::vector<PyObject *> call_to_list(std::string attr_name, PyObject *args, PyObject *kwargs);
 	PyObject *wrap_function(PyObject *function);
 	PyObject *import_decorator();
+	PyObject *import_decorator_class();
+	PyObject *import_from_ducktables(std::string attr_name);
 };
 
 } // namespace pyudf

--- a/src/pyconvert.cpp
+++ b/src/pyconvert.cpp
@@ -237,7 +237,7 @@ std::vector<duckdb::LogicalType> PyTypesToLogicalTypes(const std::vector<PyObjec
 			}
 
 			// Release the reference to the type name object
-			Py_XDECREF(typeNameObj);
+			Py_DECREF(typeNameObj);
 		}
 	}
 

--- a/src/pyconvert.cpp
+++ b/src/pyconvert.cpp
@@ -162,7 +162,7 @@ void ConvertPyObjectsToDuckDBValues(PyObject *py_iterator, std::vector<duckdb::L
 
 PyObject *pyObjectToIterable(PyObject *py_object) {
 	cpy::Object obj(py_object);
-	cpy::Object iterable_class = cpy::Module("collections.abc").getattr("Iterable");
+	cpy::Object iterable_class = cpy::Module("collections.abc").attr("Iterable");
 	if (!obj.isinstance(iterable_class)) {
 		throw std::runtime_error("Object is not an iterable, presumably...");
 	}

--- a/src/pyconvert.cpp
+++ b/src/pyconvert.cpp
@@ -161,13 +161,13 @@ void ConvertPyObjectsToDuckDBValues(PyObject *py_iterator, std::vector<duckdb::L
 }
 
 PyObject *pyObjectToIterable(PyObject *py_object) {
-        cpy::Object obj(py_object); 
-        cpy::Object iterable_class = cpy::Module("collections.abc").getattr("Iterable");
-        if(!obj.isinstance(iterable_class)) {
-          throw std::runtime_error("Object is not an iterable, presumably...");
-        }
-        auto iterobj = obj.iter();
-        return iterobj.getpy();
+	cpy::Object obj(py_object);
+	cpy::Object iterable_class = cpy::Module("collections.abc").getattr("Iterable");
+	if (!obj.isinstance(iterable_class)) {
+		throw std::runtime_error("Object is not an iterable, presumably...");
+	}
+	auto iterobj = obj.iter();
+	return iterobj.getpy();
 }
 
 PyObject *StructToDict(duckdb::Value value) {
@@ -257,7 +257,7 @@ bool PyIsInstance(PyObject *instance, PyObject *classObj) {
 	if (!instance || !classObj) {
 		return false; // Either instance or classObj is a null pointer.
 	}
-        cpy::Object inst(instance);
-        return inst.isinstance(classObj);
+	cpy::Object inst(instance);
+	return inst.isinstance(classObj);
 }
 } // namespace pyudf

--- a/src/pyscalar.cpp
+++ b/src/pyscalar.cpp
@@ -33,16 +33,16 @@ static void PyScalarFunction(DataChunk &args, ExpressionState &state, Vector &re
 		PythonException *error;
 		std::tie(pyresult, error) = func.call(pyargs);
 		if (!pyresult) {
-			Py_XDECREF(pyresult);
-			Py_XDECREF(pyargs);
+			Py_DECREF(pyresult);
+			Py_DECREF(pyargs);
 			std::string err = error->message;
 			error->~PythonException();
 			throw std::runtime_error(err);
 		} else {
 			auto ddb_result = ConvertPyObjectToDuckDBValue(pyresult, duckdb::LogicalTypeId::VARCHAR);
 			result.SetValue(row, ddb_result);
-			Py_XDECREF(pyargs);
-			Py_XDECREF(pyresult);
+			Py_DECREF(pyargs);
+			Py_DECREF(pyresult);
 		}
 	}
 }

--- a/src/pyscalar.cpp
+++ b/src/pyscalar.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include "python_function.hpp"
 #include "pyconvert.hpp"
+#include <log.hpp>
 
 using namespace duckdb;
 namespace pyudf {
@@ -33,7 +34,6 @@ static void PyScalarFunction(DataChunk &args, ExpressionState &state, Vector &re
 		PythonException *error;
 		std::tie(pyresult, error) = func.call(pyargs);
 		if (!pyresult) {
-			Py_DECREF(pyresult);
 			Py_DECREF(pyargs);
 			std::string err = error->message;
 			error->~PythonException();

--- a/src/pytable.cpp
+++ b/src/pytable.cpp
@@ -49,7 +49,10 @@ void FinalizePyTable(PyScanBindData &bind_data) {
 	Py_ssize_t size = PyTuple_Size(bind_data.arguments);
 	for (Py_ssize_t i = 0; i < size; i++) {
 		PyObject *arg = PyTuple_GetItem(bind_data.arguments, i);
-		Py_XDECREF(arg);
+		// Traced a SegFault that is prevented by not issueing this decref. There
+		// is probably some side effect here that I'm not accounting for, and not
+		// an issue with this decref per say.
+		// Py_DECREF(arg);
 	}
 }
 
@@ -234,12 +237,12 @@ unique_ptr<FunctionData> PyBind(ClientContext &context, TableFunctionBindInput &
 	PythonException *error;
 	std::tie(iter, error) = result->pyfunc->call(result->arguments, result->kwargs);
 	if (!iter) {
-		Py_XDECREF(iter);
+		Py_DECREF(iter);
 		std::string err = error->message;
 		error->~PythonException();
 		throw std::runtime_error(err);
 	} else if (!PyIter_Check(iter)) {
-		Py_XDECREF(iter);
+		Py_DECREF(iter);
 		throw std::runtime_error("Error: function '" + result->pyfunc->function_name() +
 		                         "' did not return an iterator\n");
 	}

--- a/src/pytable.cpp
+++ b/src/pytable.cpp
@@ -237,7 +237,6 @@ unique_ptr<FunctionData> PyBind(ClientContext &context, TableFunctionBindInput &
 	PythonException *error;
 	std::tie(iter, error) = result->pyfunc->call(result->arguments, result->kwargs);
 	if (!iter) {
-		Py_DECREF(iter);
 		std::string err = error->message;
 		error->~PythonException();
 		throw std::runtime_error(err);

--- a/src/python_table_function.cpp
+++ b/src/python_table_function.cpp
@@ -53,8 +53,8 @@ PyObject *PythonTableFunction::wrap_function(PyObject *function) {
 		auto is_decorator = PyIsInstance(function, decorator_cls);
 		if (is_decorator) {
 			debug("Our function is already wrapped. Nothing to do here.");
-			Py_XDECREF(decorator);
-			Py_XDECREF(decorator_cls);
+			Py_DECREF(decorator);
+			Py_DECREF(decorator_cls);
 			return function;
 		} else {
 			debug("our function is not wrapped, applying the decorator");
@@ -124,7 +124,7 @@ PyObject *PythonTableFunction::import_from_ducktables(std::string attr_name) {
 		debug("Attribute not found returning null");
 		PyErr_Print();
 	}
-	Py_XDECREF(module_obj);
+	Py_DECREF(module_obj);
 	return attr;
 }
 PyObject *PythonTableFunction::import_decorator() {
@@ -152,7 +152,7 @@ std::vector<PyObject *> PythonTableFunction::call_to_list(std::string attr_name,
 
 	if (!PyCallable_Check(method)) {
 		debug("Our method has a '" + attr_name + "' attribute, but it is not callabe");
-		Py_XDECREF(method);
+		Py_DECREF(method);
 		return items;
 	}
 
@@ -160,7 +160,7 @@ std::vector<PyObject *> PythonTableFunction::call_to_list(std::string attr_name,
 	PyObject *result = PyObject_Call(method, args, kwargs);
 	if (!result) {
 		debug("The function's " + attr_name + " method returned null. Did an error occur?");
-		Py_XDECREF(method);
+		Py_DECREF(method);
 		return items;
 	}
 
@@ -168,8 +168,8 @@ std::vector<PyObject *> PythonTableFunction::call_to_list(std::string attr_name,
 	PyObject *listResult = PySequence_List(result);
 	if (!listResult) {
 		debug("Unable to convert " + attr_name + "() return to a list. Maybe an error?");
-		Py_XDECREF(result);
-		Py_XDECREF(method);
+		Py_DECREF(result);
+		Py_DECREF(method);
 		return items;
 	}
 
@@ -185,9 +185,9 @@ std::vector<PyObject *> PythonTableFunction::call_to_list(std::string attr_name,
 		items.push_back(listItem);
 	}
 
-	Py_XDECREF(result);
-	Py_XDECREF(listResult);
-	Py_XDECREF(method);
+	Py_DECREF(result);
+	Py_DECREF(listResult);
+	Py_DECREF(method);
 	return items;
 }
 

--- a/src/python_table_function.cpp
+++ b/src/python_table_function.cpp
@@ -46,9 +46,20 @@ PyObject *PythonTableFunction::wrap_function(PyObject *function) {
 		return nullptr;
 	}
 
-	// TODO TODO TODO
-	// check if the function is already wrapped using isinstance(), return it if so
-	// TODO TODO TODO
+	auto decorator_cls = import_decorator_class();
+	if (!decorator_cls) {
+		debug("We didn't get a decorator class even though we have a decoartor? Weird. Skipping check");
+	} else {
+		auto is_decorator = PyIsInstance(function, decorator_cls);
+		if (is_decorator) {
+			debug("Our function is already wrapped. Nothing to do here.");
+			Py_XDECREF(decorator);
+			Py_XDECREF(decorator_cls);
+			return function;
+		} else {
+			debug("our function is not wrapped, applying the decorator");
+		}
+	}
 
 	// Otherwise, go ahead and wrappe it
 	debug("Creating a tuple for arguments");
@@ -96,7 +107,7 @@ PyObject *PythonTableFunction::wrap_function(PyObject *function) {
 	return wrapped_function;
 }
 
-PyObject *PythonTableFunction::import_decorator() {
+PyObject *PythonTableFunction::import_from_ducktables(std::string attr_name) {
 	debug("Calling import module");
 	PyObject *module_obj = PyImport_ImportModule("ducktables");
 	debug("Completed calling import module");
@@ -107,96 +118,106 @@ PyObject *PythonTableFunction::import_decorator() {
 		return nullptr;
 	}
 	debug("Getting the attribute...");
-	PyObject *function_obj = PyObject_GetAttrString(module_obj, "ducktable");
-	if (!function_obj) {
+	PyObject *attr = PyObject_GetAttrString(module_obj, attr_name.c_str());
+	if (!attr) {
 		// todo: Maybe we want to report this error if it isn't just import error?
 		debug("Attribute not found returning null");
 		PyErr_Print();
-		return nullptr;
 	}
-	debug("Got the function, now returning");
+	Py_XDECREF(module_obj);
+	return attr;
+}
+PyObject *PythonTableFunction::import_decorator() {
+	auto function_obj = import_from_ducktables("ducktable");
 	return function_obj;
 }
 
-std::vector<PyObject *> PythonTableFunction::pycolumn_types(PyObject *args, PyObject *kwargs) {
-	std::vector<PyObject *> columnTypes;
+PyObject *PythonTableFunction::import_decorator_class() {
+	auto cls_obj = import_from_ducktables("DuckTableSchemaWrapper");
+	return cls_obj;
+}
+
+// Given an attribute on our Python Function object, call it with the supplied arguments and coerce an expected
+// list-like object
+std::vector<PyObject *> PythonTableFunction::call_to_list(std::string attr_name, PyObject *args, PyObject *kwargs) {
+	std::vector<PyObject *> items;
 
 	// Get the 'column_types' method
-	PyObject *columnTypesMethod = PyObject_GetAttrString(function, "column_types");
+	PyObject *method = PyObject_GetAttrString(function, attr_name.c_str());
 
-	// Check if the 'column_types' method exists
-	if (columnTypesMethod && PyCallable_Check(columnTypesMethod)) {
-		// Invoke the 'column_types' method with args and kwargs
-		PyObject *result = PyObject_Call(columnTypesMethod, args, kwargs);
-
-		// Check if the return value is a list
-		if (result && PyList_Check(result)) {
-			Py_ssize_t listSize = PyList_Size(result);
-
-			// Iterate over the list elements
-			for (Py_ssize_t i = 0; i < listSize; ++i) {
-				PyObject *listItem = PyList_GetItem(result, i);
-
-				// Add the list item to the columnTypes vector
-				Py_INCREF(listItem);
-				columnTypes.push_back(listItem);
-			}
-		}
-
-		// Release the reference to the result
-		Py_XDECREF(result);
+	if (!method) {
+		debug("No '" + attr_name + "' attribute on our method object");
+		return items;
 	}
 
-	// Release the reference to the 'column_types' method
-	Py_XDECREF(columnTypesMethod);
+	if (!PyCallable_Check(method)) {
+		debug("Our method has a '" + attr_name + "' attribute, but it is not callabe");
+		Py_XDECREF(method);
+		return items;
+	}
 
-	return columnTypes;
+	// Invoke the method with args and kwargs
+	PyObject *result = PyObject_Call(method, args, kwargs);
+	if (!result) {
+		debug("The function's " + attr_name + " method returned null. Did an error occur?");
+		Py_XDECREF(method);
+		return items;
+	}
+
+	// Try to convert our result into a list. This way users can return a tuple or list or iterable or whatever.
+	PyObject *listResult = PySequence_List(result);
+	if (!listResult) {
+		debug("Unable to convert " + attr_name + "() return to a list. Maybe an error?");
+		Py_XDECREF(result);
+		Py_XDECREF(method);
+		return items;
+	}
+
+	// Copy the objects to our return vector
+	Py_ssize_t listSize = PyList_Size(listResult);
+
+	// Iterate over the list elements
+	for (Py_ssize_t i = 0; i < listSize; ++i) {
+		PyObject *listItem = PyList_GetItem(listResult, i);
+
+		// Add the list item to the vector
+		Py_INCREF(listItem);
+		items.push_back(listItem);
+	}
+
+	Py_XDECREF(result);
+	Py_XDECREF(listResult);
+	Py_XDECREF(method);
+	return items;
+}
+
+std::vector<PyObject *> PythonTableFunction::pycolumn_types(PyObject *args, PyObject *kwargs) {
+	return call_to_list("column_types", args, kwargs);
 }
 
 std::vector<duckdb::LogicalType> PythonTableFunction::column_types(PyObject *args, PyObject *kwargs) {
 	auto python_types = pycolumn_types(args, kwargs);
 	// todo: check for a Python error?
+	// todo: decrement references to types
 	auto ddb_types = PyTypesToLogicalTypes(python_types);
 	return ddb_types;
 }
 
 std::vector<std::string> PythonTableFunction::column_names(PyObject *args, PyObject *kwargs) {
+	std::vector<PyObject *> pyColumnNames = call_to_list("column_names", args, kwargs);
 	std::vector<std::string> columnNames;
 
-	// Get the 'column_names' method
-	PyObject *columnNamesMethod = PyObject_GetAttrString(function, "column_names");
-
-	// Check if the 'column_names' method exists
-	if (columnNamesMethod && PyCallable_Check(columnNamesMethod)) {
-		// Invoke the 'column_names' method with args and kwargs
-		PyObject *result = PyObject_Call(columnNamesMethod, args, kwargs);
-
-		// Check if the return value is a list
-		if (result && PyList_Check(result)) {
-			Py_ssize_t listSize = PyList_Size(result);
-			debug("Number of column names returned by Python:  " + std::to_string(listSize));
-			// Iterate over the list elements
-			for (Py_ssize_t i = 0; i < listSize; ++i) {
-				PyObject *listItem = PyList_GetItem(result, i);
-
-				// Convert the list item to a C++ string
-				if (PyUnicode_Check(listItem)) {
-					const char *columnName = Unicode_AsUTF8(listItem);
-					columnNames.emplace_back(columnName);
-					// todo: free columnName?????
-				} else {
-					// todo: this will break something by leaving out a column name
-				}
-			}
+	for (auto listItem : pyColumnNames) {
+		if (PyUnicode_Check(listItem)) {
+			const char *columnName = Unicode_AsUTF8(listItem);
+			columnNames.emplace_back(columnName);
+			// todo: free columnName?????
+			// todo: free listItem;
+		} else {
+			debug("One of the column names isn't a unicode value? What do we do here?");
+			// todo: this will break something by leaving out a column name
 		}
-
-		// Release the reference to the result
-		Py_XDECREF(result);
 	}
-
-	// Release the reference to the 'column_names' method
-	Py_XDECREF(columnNamesMethod);
-	debug("Number of column names in our C++ vector:  " + std::to_string(columnNames.size()));
 	return columnNames;
 }
 

--- a/test/ducktables-integration/aws.test
+++ b/test/ducktables-integration/aws.test
@@ -1,0 +1,32 @@
+# name: test/ducktables-integration/aws.test
+# description: Test AWS Functions
+# group: [ducktables-integration]
+
+# Require statement will ensure this test is run with this extension loaded
+require pytables
+
+# Query EC2 Instances
+query I
+SELECT name
+FROM pytable('ducktables.aws:ec2_instances')
+----
+mroddy-personal-development
+
+
+# Query S3 Buckets
+query I
+SELECT name
+FROM pytable('ducktables.aws:s3_buckets')
+WHERE name like 'net.ednit.duckdb-%';
+----
+net.ednit.duckdb-extensions
+
+# Query Objects in S3 Bucket
+query I
+SELECT key
+FROM pytable('ducktables.aws:s3_objects', 'net.ednit.duckdb-extensions', 'pytables/latest/python3.9/')
+----
+pytables/latest/python3.9/v0.8.0/linux_amd64/pytables.duckdb_extension.gz
+
+
+

--- a/test/ducktables-integration/github.test
+++ b/test/ducktables-integration/github.test
@@ -1,0 +1,14 @@
+# name: test/ducktables-integration/github.test
+# description: Test Github Table Functions
+# group: [ducktables-integration]
+
+# Require statement will ensure this test is run with this extension loaded
+require pytables
+
+
+# Test the Google Sheets integration with their supplied readonly sheet
+query III
+SELECT * FROM pytable('ducktables.github:repos_for', 'duckdb')
+WHERE repo = 'duckdb';
+----
+duckdb	DuckDB is an in-process SQL OLAP Database Management System	C++

--- a/test/ducktables-integration/openai.test
+++ b/test/ducktables-integration/openai.test
@@ -1,0 +1,16 @@
+# name: test/ducktables-integration/openai.test
+# description: Test OpenAI Table Functions
+# group: [ducktables-integration]
+
+# Require statement will ensure this test is run with this extension loaded
+require pytables
+
+
+# Test the Google Sheets integration with their supplied readonly sheet
+query IIII
+SELECT * FROM pytable('ducktables.openai:prompt', 'Please respond with the "Hello" and no other words. Do not include any punctuation either.', 1);
+----
+0	Hello	assistant	stop
+
+
+

--- a/test/ducktables-integration/openai.test
+++ b/test/ducktables-integration/openai.test
@@ -8,7 +8,7 @@ require pytables
 
 # Test the Google Sheets integration with their supplied readonly sheet
 query IIII
-SELECT * FROM pytable('ducktables.openai:prompt', 'Please respond with the "Hello" and no other words. Do not include any punctuation either.', 1);
+SELECT * FROM pytable('ducktables.openai:prompt', 'Please respond with the "Hello" and no other words. The word "Hello" should be capitalized. Also, do not include any punctuation.', 1);
 ----
 0	Hello	assistant	stop
 


### PR DESCRIPTION
This way you can use them w/o specifying their output schema.

Note the one exception here is the Google related functions which have variable output schemas depending on the function's input arguments. Will revisit these in a bit.