### PR TITLE
[WIP] Add Support for Functions Returning datetime Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 0.1.5 (pending)
+
+Features:
+* Python datetime types (time, date, datetime) now converted to native DuckDB types.
+
 # 0.1.4
 
 Features:

--- a/src/cpy/module.cpp
+++ b/src/cpy/module.cpp
@@ -4,7 +4,8 @@
 #include <cpy/module.hpp>
 
 namespace cpy {
-Module::Module(const std::string &module_name) : cpy::Object(doImport(module_name), true) {
+	Module::Module() {}
+	Module::Module(const std::string &module_name) : cpy::Object(doImport(module_name), true) {
 	module_name_ = module_name;
 }
 

--- a/src/cpy/object.cpp
+++ b/src/cpy/object.cpp
@@ -1,10 +1,15 @@
 
+
+#include <cstdarg>
 #include <Python.h>
 #include <stdexcept>
+
+#include <log.hpp>
 #include <cpy/object.hpp>
 #include <cpy/exception.hpp>
 
 namespace cpy {
+bool _disable_cpy_deallocation = std::getenv("PYTABLES_DISABLE_CPY_AUTO_DEALLOCATION") != nullptr;
 cpy::Object list(cpy::Object src) {
 	auto pysrc = src.getpy();
 	PyObject *pylist = PySequence_List(pysrc);
@@ -17,53 +22,110 @@ cpy::Object list(cpy::Object src) {
 	}
 }
 
-PyObject *Object::getpy() {
-	Py_XINCREF(obj);
+cpy::Object tuple(std::vector<cpy::Object> items) {
+	PyObject *tpl = PyTuple_New(items.size());
+	if(!tpl) {
+		throw std::runtime_error("Failed to allocate new tuple");
+	}
+	for (size_t i = 0; i < items.size(); i++) {
+		// Reference Counting Note:
+		// cpy::Object.getpy() increments the reference so this function owns a ref to
+		// the PyObject value. But PyTuple_SetItem() "steals" (their word) a reference,
+		// ie - it doesn't increment. So we effectively hand the reference from getpy()
+		// to SetItem(), so there's no reference decrementation necessary.		
+		PyObject *pyval = items[i].getpy();
+		auto result = PyTuple_SetItem(tpl, i, pyval);
+		if (PyErr_Occurred()) {
+			throw cpy::Exception::gather();
+		} else if(0 != result) {
+			throw std::runtime_error("Failed to allocate python tuple");
+		}
+	}
+	cpy::Object tobj(tpl, true);
+	return tobj;
+}
+
+std::string Object::debug_tostring() {
+	auto iptr = reinterpret_cast<std::uintptr_t>(obj);
+	return "cpy::Object(" + std::to_string(iptr) + ")";
+}
+	
+PyObject *Object::getpy() const {
+	Py_INCREF(obj);
 	return obj;
 }
 
 Object::Object() {
 	obj = nullptr;
+	debug_disable_deallocation = false;
+	_repr = repr();
 }
 
 Object::Object(PyObject *obj) : obj(obj) {
 	Py_XINCREF(obj);
+	debug_disable_deallocation = false;
+	_repr = repr();
 }
 
 Object::Object(PyObject *obj, bool assumeOwnership) : obj(obj) {
 	if (!assumeOwnership) {
 		Py_INCREF(obj);
 	}
+	debug_disable_deallocation = false;
+	_repr = repr();
 }
-
+	
 Object::~Object() {
-	Py_XDECREF(obj);
+	if (_disable_cpy_deallocation) {
+		pyudf::debug("Skipping Py_XDECREF as it is globally disabled");
+	} else if (debug_disable_deallocation) {
+		pyudf::debug("Skipping Py_XDECREF as it is disabled for this object");
+	} else {
+		if(!isempty()) {
+			pyudf::debug("Decrementing a Python Object ref count on: '", false);
+			pyudf::debug(_repr, false);
+			pyudf::debug("'");
+		}
+		Py_XDECREF(obj);
+	}
 	obj = nullptr;
 }
 
 // copy
-Object::Object(const Object &other) : obj(other.obj) {
-	Py_XINCREF(obj);
+Object::Object(const Object &other) : obj(other.getpy()), debug_disable_deallocation(other.debug_disable_deallocation) {
+	// Note we call getpy() to ensure that the Py_XINCREF() is called before
+	// it is assigned (and theoretically usable). It is unclear if that should
+	// be a concern or not.
+_repr = repr();	
 }
 
 // Move
-Object::Object(Object &&other) : obj(other.obj) {
+Object::Object(Object &&other) : obj(other.obj), debug_disable_deallocation(other.debug_disable_deallocation) {
 	other.obj = nullptr;
+	_repr = repr();
 }
 
 Object &Object::operator=(const Object &other) {
 	Py_XINCREF(obj);
 	obj = other.obj;
+	debug_disable_deallocation = other.debug_disable_deallocation;
+	_repr = repr();
 	return *this;
 }
 
-cpy::Object Object::attr(const std::string &attribute_name) {
+cpy::Object Object::attr(const std::string &attribute_name) const {
 	PyObject *attr = PyObject_GetAttrString(obj, attribute_name.c_str());
 	if (!attr) {
 		// todo: check if no such attribute, or some other error.
 		throw std::runtime_error("Failed to access attribute: " + attribute_name);
 	} else {
-		return cpy::Object(attr);
+		// std::string child_name;
+		// if(name.empty()) {
+		// 	child_name = "." + attribute_name;
+		// } else {
+		// 	child_name = name + "." + attribute_name;
+		// }
+		return cpy::Object(attr, true);
 	}
 }
 
@@ -79,30 +141,30 @@ bool Object::isinstance(PyObject *cls) {
 	return is_cls;
 }
 
-bool Object::isempty() {
+bool Object::isempty() const {
 	return (nullptr == obj);
 }
 
-bool Object::isnone() {
+bool Object::isnone() const {
 	return (Py_None == obj);
 }
 
-bool Object::callable() {
+bool Object::callable() const {
 	return PyCallable_Check(obj);
 }
 
 cpy::Object Object::call(cpy::Object args) const {
-	auto pyargs = args.getpy();
-	PyObject *result = PyObject_CallObject(obj, pyargs);
-	Py_XDECREF(pyargs);
-
-	if (PyErr_Occurred()) {
-		throw cpy::Exception();
-	} else if (!result) {
-		throw std::runtime_error("Error calling function");
-	} else {
-		return cpy::Object(result, true);
+	if(isempty()) {
+		throw std::runtime_error("Object::call() on a null pointer");
 	}
+	if(args.isempty()) {
+		throw std::runtime_error("Object::call() with args that is a null pointer");
+	}
+
+	PyObject* pyargs = args.getpy();
+	cpy::Object result = call(pyargs);
+	Py_DECREF(pyargs);
+	return result;
 }
 
 cpy::Object Object::call(cpy::Object args, cpy::Object kwargs) const {
@@ -112,7 +174,8 @@ cpy::Object Object::call(cpy::Object args, cpy::Object kwargs) const {
 	Py_XDECREF(pyargs);
 	Py_XDECREF(pykwargs);
 	if (PyErr_Occurred()) {
-		throw cpy::Exception();
+		Py_XDECREF(result);
+		throw cpy::Exception::gather();
 	} else if (!result) {
 		throw std::runtime_error("Error calling function");
 	} else {
@@ -120,16 +183,70 @@ cpy::Object Object::call(cpy::Object args, cpy::Object kwargs) const {
 	}
 }
 
+	cpy::Object Object::call() const {
+		PyObject *result = PyObject_CallObject(obj, NULL);
+		if (PyErr_Occurred()) {
+			Py_XDECREF(result);
+			throw cpy::Exception::gather();
+			// throw std::runtime_error(err.message());
+		} else if (!result) {
+			throw std::runtime_error("Error calling function");
+		} else {
+			return cpy::Object(result, true);
+		}	
+	}
+
 cpy::Object Object::call(PyObject *pyargs) const {
-	auto args = cpy::Object(pyargs);
-	return call(args);
+	// cpy::Object args = cpy::Object(pyargs, false, "args for " + name + "()");
+	// return call(args);
+		// PyObject* pyargs = args.getpy();
+	if (!PyTuple_Check(pyargs)) {
+		throw std::runtime_error("Arguments passed in as non-Python Tuple");
+	}
+	// pyargs = PyTuple_New(0);
+	PyObject* pykwargs = PyDict_New();
+	// PyObject *result = PyObject_CallObject(obj, pyargs);
+	// PyObject* result = PyObject_Call(obj, pyargs, pykwargs);
+	return call(pyargs, pykwargs);
+	// Py_XDECREF(pyargs);
+
+	// if (PyErr_Occurred()) {
+	// 	throw cpy::Exception::gather();
+	// } else if (!result) {
+	// 	throw std::runtime_error("Error calling function");
+	// } else {
+	// 	return cpy::Object(result, true);
+	// }
 }
 
 cpy::Object Object::call(PyObject *pyargs, PyObject *pykwargs) const {
-	auto args = cpy::Object(pyargs);
-	auto kwargs = cpy::Object(pykwargs);
+	auto args = cpy::Object(pyargs, false);
+	auto kwargs = cpy::Object(pykwargs, false);
 	return call(args, kwargs);
 }
+	
+	cpy::Object Object::callattr(std::string name) const {
+		cpy::Object func = attr(name);
+		return func.call();
+	}
+	cpy::Object Object::callattr(std::string name, cpy::Object pyargs) const {
+		cpy::Object func = attr(name);
+		return func.call(pyargs);
+	}
+	cpy::Object Object::callattr(std::string name, cpy::Object pyargs, cpy::Object pykwargs) const {
+		cpy::Object func = attr(name);
+		return func.call(pyargs, pykwargs);
+	}
+	
+	cpy::Object Object::callattr(std::string name, PyObject* pyargs) const {
+		cpy::Object func = attr(name);
+		return func.call(pyargs);
+	}
+	
+	cpy::Object Object::callattr(std::string name, PyObject* pyargs, PyObject* pykwargs) const {
+		cpy::Object func = attr(name);
+		return func.call(pyargs, pykwargs);
+	}
 
 cpy::Object Object::iter() {
 	PyObject *py_iter = PyObject_GetIter(obj);
@@ -137,10 +254,22 @@ cpy::Object Object::iter() {
 		// todo: include python error
 		throw std::runtime_error("Failed to convert to an iterator");
 	} else {
-		cpy::Object itrobj(py_iter);
-		Py_DECREF(py_iter);
+		cpy::Object itrobj(py_iter, true);
 		return itrobj;
 	}
+}
+
+std::string Object::repr() {
+	if (isempty()) {
+		return "<nullptr>";
+	}
+	return str();
+	PyObject *py_repr = PyObject_Repr(obj);
+	if (!py_repr) {
+		throw std::runtime_error("Failed to convert to a python string");
+	}
+	cpy::Object repr(py_repr);
+	return repr.str();
 }
 
 std::string Object::str() {
@@ -167,4 +296,12 @@ std::string Object::str() {
 	return str;
 }
 
+int32_t Object::toInt() {
+	if (!PyLong_Check(obj)) {
+		throw std::runtime_error("Can not convert non-PyLong to int");
+	} else {
+		// todo: error check?
+		return (int32_t)PyLong_AsLong(obj);
+	}
+}
 } // namespace cpy

--- a/src/include/cpy/exception.hpp
+++ b/src/include/cpy/exception.hpp
@@ -3,16 +3,17 @@
 #define CPY_EXCEPTION_HPP
 
 #include <string>
+#include <stdexcept>
 #include <Python.h>
 #include <cpy/object.hpp>
 
 namespace cpy {
-class Exception {
+class Exception : std::runtime_error {
 
 public:
-	Exception();
-	Exception(cpy::Object pytype, cpy::Object pymessage, cpy::Object pytraceback, std::string _type,
-	          std::string _message, std::string _traceback);
+	static Exception gather();
+	// Exception();
+	Exception(std::string _type, std::string _message, std::string _traceback);
 
 	Exception(const Exception &);                 // copy
 	Exception(Exception &&);                      // move
@@ -22,13 +23,10 @@ public:
 	std::string traceback() const;
 
 private:
-	cpy::Object pytype;
-	cpy::Object pymessage;
-	cpy::Object pytraceback;
-
 	std::string _type;
 	std::string _message;
 	std::string _traceback;
+	
 };
 
 } // namespace cpy

--- a/src/include/cpy/module.hpp
+++ b/src/include/cpy/module.hpp
@@ -10,6 +10,7 @@ namespace cpy {
 class Module : public cpy::Object {
 
 public:
+	Module();
 	Module(const std::string &module_name);
 
 private:

--- a/src/include/cpy/object.hpp
+++ b/src/include/cpy/object.hpp
@@ -2,6 +2,8 @@
 #ifndef CPY_OBJECT_HPP
 #define CPY_OBJECT_HPP
 
+#include <vector>
+#include <string>
 #include <Python.h>
 
 namespace cpy {
@@ -10,34 +12,53 @@ public:
 	Object();
 	Object(PyObject *obj);
 	Object(PyObject *obj, bool assumeOwnership);
+	
 	~Object();
 	Object(const Object &);                 // copy
 	Object(Object &&);                      // move
 	Object &operator=(const Object &other); // copy assignment
 
 	/* Grab the pointer to the underlying python object, increments its reference count */
-	PyObject *getpy();
+	PyObject *getpy() const;
 
-	cpy::Object attr(const std::string &attribute_name);
+	cpy::Object attr(const std::string &attribute_name) const;
 	bool isinstance(cpy::Object cls);
 	bool isinstance(PyObject *cls);
-	bool isempty();
-	bool isnone();
+	bool isempty() const;
+	bool isnone() const;
 
-	bool callable();
+	bool callable() const;
+	cpy::Object call() const;
+
 	cpy::Object call(cpy::Object args) const;
 	cpy::Object call(cpy::Object args, cpy::Object kwargs) const;
-	cpy::Object call(PyObject *pyargs) const;
-	cpy::Object call(PyObject *pyargs, PyObject *pykwargs) const;
+
+	cpy::Object callattr(std::string name) const;
+	cpy::Object callattr(std::string name, cpy::Object pyargs) const;
+	cpy::Object callattr(std::string name, cpy::Object pyargs, cpy::Object pykwargs) const;	
+
+	// Kill these once we've refactored all code directly using CPython functions
+	cpy::Object call(PyObject* pyargs) const;
+	cpy::Object call(PyObject* pyargs, PyObject* pykwargs) const;
+	cpy::Object callattr(std::string name, PyObject* pyargs) const;
+	cpy::Object callattr(std::string name, PyObject* pyargs, PyObject* pykwargs) const;
 
 	cpy::Object iter();
-
 	std::string str();
+	std::string repr();
 
+	int32_t toInt();
+
+	// Debugging tool to aid in GC related issues.
+	bool debug_disable_deallocation;
+	std::string debug_tostring();
 protected:
 	PyObject *obj;
+	// std::string name;
+	std::string _repr;
 };
 
 cpy::Object list(cpy::Object src);
+cpy::Object tuple(std::vector<cpy::Object> items);
 } // namespace cpy
 #endif // CPY_OBJECT_HPP

--- a/src/include/log.hpp
+++ b/src/include/log.hpp
@@ -9,6 +9,6 @@ namespace pyudf {
 // Initialize at the start of the program
 extern bool _debugEnabled;
 
-void debug(const std::string &msg);
+void debug(const std::string &msg, bool print_endl = true);
 } // namespace pyudf
 #endif

--- a/src/include/py_to_ddb.hpp
+++ b/src/include/py_to_ddb.hpp
@@ -1,0 +1,40 @@
+#ifndef PYTODDB_H
+#define PYTODDB_H
+
+#include <Python.h>
+#include <duckdb.hpp>
+#include <cpy/object.hpp>
+#include <cpy/module.hpp>
+
+namespace pyudf {
+
+// std::pair<std::string, std::string> parse_func_specifier(std::string function_specifier);
+
+class PyToDDB {
+public:
+	PyToDDB();
+
+	duckdb::Value convert(PyObject* src, duckdb::LogicalType dest_type);
+	duckdb::Value convert(cpy::Object src, duckdb::LogicalType dest_type);
+	duckdb::Value toTime(cpy::Object src);
+	duckdb::Value toDate(cpy::Object src);
+	duckdb::Value toTimeStampTZ(cpy::Object src);
+
+protected:
+	duckdb::dtime_t toDtime(cpy::Object src);
+	duckdb::date_t toDate_t(cpy::Object src);
+	cpy::Object dtToUtc(cpy::Object src);
+
+private:
+	// Cache import of the datetime module
+	cpy::Module modDatetime;
+
+	// Cache attributes of the datetime module
+	cpy::Object clsTime;
+	cpy::Object clsDate;
+	cpy::Object clsDatetime;
+	cpy::Object tzUtc;
+};
+
+} // namespace pyudf
+#endif // PYTODDB_H

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -10,7 +10,7 @@ void debug(const std::string &msg, bool print_endl) {
 		if (print_endl) {
 			std::cerr << msg << std::endl;
 		} else {
-			std::cerr << msg << std::endl;
+			std::cerr << msg;
 		}
 	}
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -5,9 +5,13 @@
 
 namespace pyudf {
 bool _debugEnabled = std::getenv("PYTABLES_DEBUG") != nullptr;
-void debug(const std::string &msg) {
+void debug(const std::string &msg, bool print_endl) {
 	if (_debugEnabled) {
-		std::cerr << msg << std::endl;
+		if (print_endl) {
+			std::cerr << msg << std::endl;
+		} else {
+			std::cerr << msg << std::endl;
+		}
 	}
 }
 } // namespace pyudf

--- a/src/py_to_ddb.cpp
+++ b/src/py_to_ddb.cpp
@@ -1,0 +1,183 @@
+
+#include <duckdb/common/types/time.hpp>
+#include <py_to_ddb.hpp>
+#include <cpy/module.hpp>
+#include <cpy/exception.hpp>
+#include <log.hpp>
+
+namespace pyudf {
+	PyToDDB::PyToDDB() {
+		modDatetime = cpy::Module("datetime");
+			
+		clsTime = modDatetime.attr("time");
+		clsDate = modDatetime.attr("date");
+		clsDatetime = modDatetime.attr("datetime");
+
+		cpy::Object tzcls = modDatetime.attr("timezone");
+		tzUtc = tzcls.attr("utc");
+	}
+
+	duckdb::Value PyToDDB::convert(PyObject* src, duckdb::LogicalType dest_type) {
+		duckdb::Value value;
+		cpy::Object cpy_src(src, "val_to_convert");
+		
+		PyObject *py_value;
+		bool conversion_failed = false;
+
+		switch (dest_type.id()) {
+		case duckdb::LogicalTypeId::BOOLEAN:
+			if (!PyBool_Check(src)) {
+				conversion_failed = true;
+			} else {
+				value = duckdb::Value(Py_True == src);
+			}
+			break;
+		case duckdb::LogicalTypeId::TINYINT:
+		case duckdb::LogicalTypeId::SMALLINT:
+		case duckdb::LogicalTypeId::INTEGER:
+			if (!PyLong_Check(src)) {
+				conversion_failed = true;
+			} else {
+				value = duckdb::Value((int32_t)PyLong_AsLong(src));
+			}
+			break;
+		case duckdb::LogicalTypeId::FLOAT:
+		case duckdb::LogicalTypeId::DOUBLE:
+			if (!PyFloat_Check(src)) {
+				conversion_failed = true;
+			} else {
+				value = duckdb::Value(PyFloat_AsDouble(src));
+			}
+			break;
+		case duckdb::LogicalTypeId::VARCHAR:
+			if (!PyUnicode_Check(src)) {
+				conversion_failed = true;
+			} else {
+				py_value = PyUnicode_AsUTF8String(src);
+				value = duckdb::Value(PyBytes_AsString(py_value));
+				Py_DECREF(py_value);
+			}
+			break;
+		case duckdb::LogicalTypeId::TIME:
+			if(!cpy_src.isinstance(clsTime)) {
+				conversion_failed = true;
+			} else {
+				value = toTime(cpy_src);
+			}
+			break;
+		case duckdb::LogicalTypeId::DATE:
+			if(!cpy_src.isinstance(clsDate)) {
+				conversion_failed = true;
+			} else {
+				value = toDate(cpy_src);
+			}
+			break;
+		case duckdb::LogicalTypeId::TIMESTAMP_TZ:
+			if(!cpy_src.isinstance(clsDatetime)) {
+				conversion_failed = true;
+			} else {
+				value = toTimeStampTZ(cpy_src);
+			}
+			break;
+
+		default:
+			conversion_failed = true;
+		}
+
+		if (conversion_failed) {
+			// DUCKDB_API Value(std::nullptr_t val); // NOLINT: Allow implicit conversion from `nullptr_t`
+			value = duckdb::Value((std::nullptr_t)NULL);
+		}
+		return value;
+
+	// 			return Value::TIME(dtime_t(0));
+	// case LogicalTypeId::TIMESTAMP:
+	// 	return Value::TIMESTAMP(Date::FromDate(Timestamp::MIN_YEAR, Timestamp::MIN_MONTH, Timestamp::MIN_DAY),
+	// 	                        dtime_t(0));
+	// case LogicalTypeId::TIMESTAMP_SEC:
+	// 	return MinimumValue(LogicalType::TIMESTAMP).DefaultCastAs(LogicalType::TIMESTAMP_S);
+	// case LogicalTypeId::TIMESTAMP_MS:
+	// 	return MinimumValue(LogicalType::TIMESTAMP).DefaultCastAs(LogicalType::TIMESTAMP_MS);
+	// case LogicalTypeId::TIMESTAMP_NS:
+	// 	return Value::TIMESTAMPNS(timestamp_t(NumericLimits<int64_t>::Minimum()));
+	// case LogicalTypeId::TIME_TZ:
+	// 	return Value::TIMETZ(dtime_t(0));
+	// case LogicalTypeId::TIMESTAMP_TZ:
+	// 	return Value::TIMESTAMPTZ(Timestamp::FromDatetime(
+	// 	    Date::FromDate(Timestamp::MIN_YEAR, Timestamp::MIN_MONTH, Timestamp::MIN_DAY), dtime_t(0)));
+
+	}
+	
+	duckdb::Value PyToDDB::convert(cpy::Object src, duckdb::LogicalType dest_type) {
+		PyObject* pysrc = src.getpy();
+		duckdb::Value val = convert(pysrc, dest_type);
+		Py_DECREF(pysrc);
+		return val;
+	}
+
+	duckdb::dtime_t PyToDDB::toDtime(cpy::Object src) {
+		int32_t hour = src.attr("hour").toInt();
+		int32_t minute = src.attr("minute").toInt();
+		int32_t second = src.attr("second").toInt();
+		int32_t microsec = src.attr("microsecond").toInt();
+		duckdb::dtime_t time = duckdb::Time::FromTime(hour, minute, second, microsec);
+		return time;
+	}
+
+	duckdb::date_t PyToDDB::toDate_t(cpy::Object src) {
+		int32_t year = src.attr("year").toInt();
+		int32_t month = src.attr("month").toInt();
+		int32_t day = src.attr("day").toInt();
+		// DUCKDB_API static date_t FromDate(int32_t year, int32_t month, int32_t day);
+		duckdb::date_t date = duckdb::Date::FromDate(year, month, day);
+		return date;
+	}
+
+	duckdb::Value PyToDDB::toTime(cpy::Object src) {
+		duckdb::dtime_t time = toDtime(src);
+		return duckdb::Value::TIME(time);
+	}
+
+	duckdb::Value PyToDDB::toDate(cpy::Object src) {
+		duckdb::date_t date = toDate_t(src);
+		return duckdb::Value::DATE(date);
+	}
+
+	cpy::Object PyToDDB::dtToUtc(cpy::Object src) {
+		cpy::Object src_tz = src.attr("tzinfo");
+		if (src_tz.isnone()) {
+			// No timezone specified so we don't do anything.
+			return src;
+		} else {
+			cpy::Object args = cpy::tuple({});
+			cpy::Object func = src.attr("astimezone");
+			cpy::Object result = func.call(args);
+			return result;
+		}
+	}
+
+	duckdb::Value PyToDDB::toTimeStampTZ(cpy::Object src) {
+		try {
+			// DUCKDB_API static Value TIMESTAMP(date_t date, dtime_t time);
+			// DUCKDB_API static Value TIMESTAMP(timestamp_t timestamp);
+			// DUCKDB_APIn static Value TIMESTAMPTZ(timestamp_t timestamp);
+			// DUCKDB_API static Value TIMESTAMP(int32_t year, int32_t month, int32_t day, int32_t hour, int32_t min, int32_t sec,
+			//                               int32_t micros);
+			// cpy::Object tz = src.callattr("tzinfo");
+			
+			// if (tz.isnone()) {
+			// no timezone, do nothing.
+			// }
+			src = dtToUtc(src);
+			duckdb::dtime_t time = toDtime(src);
+			duckdb::date_t date = toDate_t(src);
+			duckdb::timestamp_t ts = duckdb::Timestamp::FromDatetime(date, time);
+			return duckdb::Value::TIMESTAMPTZ(ts);
+		} catch (cpy::Exception &ex) {
+			debug("Python Error converting datetime.datetime: " + ex.message());
+			return duckdb::Value((std::nullptr_t)NULL);
+		}
+	}
+		
+	
+} // namespace pyudf

--- a/src/python_function.cpp
+++ b/src/python_function.cpp
@@ -1,3 +1,5 @@
+
+#include <log.hpp>
 #include <duckdb.hpp>
 #include <python_function.hpp>
 #include <python_exception.hpp>
@@ -22,6 +24,7 @@ void PythonFunction::init(const std::string &module_name, const std::string &fun
 	function_name_ = function_name;
 	module = nullptr;
 	function = nullptr;
+	debug("Attempting to import: " + module_name);
 	PyObject *module_obj = PyImport_ImportModule(module_name.c_str());
 	if (!module_obj) {
 		PyErr_Print();

--- a/test/sql/pytable_type_conversions.test
+++ b/test/sql/pytable_type_conversions.test
@@ -1,0 +1,45 @@
+# name: test/sql/pytable_type_conversions.test
+# description: test conversion of Python types to DuckDB types
+# group: [pytables]
+
+
+# Require statement will ensure this test is run with this extension loaded
+require pytables
+
+# Check the conversion of datetime.time objects, note the timezone is explicitly dropped as DuckDB Time objects don't support TZ
+# def repeat_timeval(num_rows, hour, minute, second, microsec, utc_offset) -> Iterable[Tuple[int, time]]:
+query II
+SELECT * FROM pytable('udfs:repeat_timeval', 2, 3, 35, 12, 5500, -7)
+----
+0	03:35:12.0055
+1	03:35:12.0055
+
+# Check conversion of datetime.date objects
+query II
+SELECT * FROM pytable('udfs:repeat_dateval', 2, 2022, 12, 25)
+----
+0	2022-12-25
+1	2022-12-25
+
+# Check conversion of datetime.datetime objects
+query II
+SELECT * FROM pytable('udfs:repeat_datetime', 2, 2022, 12, 25, 3, 45, 12, 5500, 0)
+----
+0	2022-12-25 03:45:12.0055+00
+1	2022-12-25 03:45:12.0055+00
+
+# Check that timezone is accounted for in the conversion of datetime objects
+query II
+SELECT * FROM pytable('udfs:repeat_datetime', 2, 2022, 12, 25, 3, 45, 12, 5500, -7)
+----
+0	2022-12-25 03:45:12.0055-07
+1	2022-12-25 03:45:12.0055-07
+
+
+# Check that Time, Date, and DateTime values are supported
+query IIIII
+SELECT * FROM pytable('udfs:table_with_date_time_values', 'foo')
+----
+0	f	03:35:12	2023-07-10	2023-07-12 02:32:15+00
+1	o	03:35:12	2023-07-10	2023-07-12 02:32:15+00
+2 	o	03:35:12	2023-07-10	2023-07-12 02:32:15+00

--- a/udfs.py
+++ b/udfs.py
@@ -46,11 +46,28 @@ def table2(one_str_input, two_str_input, three_int_input):
         yield [c]
     yield [str(three_int_input)]
 
-
 def table_throws_exception(input):
     raise Exception("This function raises an exception")
 
+from datetime import date, datetime, time, timedelta, timezone
+def repeat_timeval(num_rows, hour, minute, second, microsec, utc_offset) -> Iterable[Tuple[int, time]]:
+    """Constructs a datetime.time value and enumerates `num_rows` rows"""
+    tz = timezone(timedelta(hours=utc_offset))
+    t = time(hour = hour, minute = minute, second = second, microsecond=microsec, tzinfo = tz)
+    for i in range(num_rows):
+        yield (i, t)
 
+def repeat_dateval(num_rows, year, month, day) -> Iterable[Tuple[int, date]]:
+    d = date(year, month, day)
+    for i in range(num_rows):
+        yield (i, d)
+
+def repeat_datetime(num_rows, year, month, day, hour, minute, second, microsec, utc_offset) -> Iterable[Tuple[int, datetime]]:
+    tz = timezone(timedelta(hours=utc_offset))
+    dt = datetime(year = year, month = month, day = day, hour = hour, minute = minute, second = second, microsecond=microsec, tzinfo = tz)
+    for i in range(num_rows):
+        yield (i, dt)
+    
 def iterator_throws_exception(input):
     yield ["foo"]
     yield ["bar"]
@@ -145,6 +162,48 @@ class TestUdfs(unittest.TestCase):
         self.assertEqual('buzz', fizzbuzz(5))
         self.assertEqual('7', fizzbuzz(7))
 
-        
+    def test_repeat_timeval(self):
+        tz_pst = timezone(timedelta(hours=-7)) # US West Coast / PST
+        t = time(hour = 3, minute = 35, second = 12, microsecond = 38, tzinfo = tz_pst)
+        actual = list(repeat_timeval(2, 3, 35, 12, 38, -7))
+        expected = [
+            (0, t),
+            (1, t)
+            ]
+        self.assertEqual(actual, expected)
+
+    def test_repeat_dateval(self):
+        d = date(2023, 7, 10)
+        actual = list(repeat_dateval(2, 2023, 7, 10))
+        expected = [
+            (0, d),
+            (1, d)
+            ]
+        self.assertEqual(actual, expected)
+
+    def test_repeat_datetime(self):
+        tz = timezone(timedelta(hours=-7)) # US West Coast / PST
+        dt = datetime(2023, 7, 10, 2, 32, 15, 5500, tz)
+        actual = list(repeat_datetime(2, 2023, 7, 10, 2, 32, 15, 5500, -7))
+        expected = [
+            (0, dt),
+            (1, dt),
+            ]
+        self.assertEqual(actual, expected)
+# def repeat_datetime(num_rows, year, month, day, hour, minute, second, microsec, utc_offset) -> Iterable[Tuple[int, datetime]]:
+# def repeate_dateval(num_rows, year, month, day) -> Iterable[Tuple[int, date]]:
+    # def test_table_with_date_time_values(self):
+    #     tz_utc = timezone(timedelta(0)) # UTC
+    #     tz_cet = timezone(timedelta(hours=1)) # Central European Time
+    #     t = time(hour = 3, minute = 35, second = 12, tzinfo = tz_cet)
+    #     d = date(2023, 7, 10)
+    #     dt = datetime(2023, 7, 12, hour = 2, minute = 32, second = 15, tzinfo = tz_utc)
+    #     actual = list(table_with_date_time_values("foo"))
+    #     expected = [
+    #         (0, 'f', t, d, dt),
+    #         (1, 'o', t, d, dt),
+    #         (2, 'o', t, d, dt)]
+    #     self.assertEqual(actual, expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Note this is not presently working. There is an issue causing a segfault which is proving difficult to track down as it is occurring in a segment of code not affected by this change, implying it's a memory corruption issue say, rather than something easier to track down like a null pointer passed into a CPython function. Stacktrace below for reference:

```shell
    #0 0x7f1ac360e95f  (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x25a95f)
    #1 0x7f1ac35e780a in PyUnicode_New (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x23380a)
    #2 0x7f1ac35bb7f0 in _PyUnicodeWriter_PrepareInternal (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x2077f0)
    #3 0x7f1ac35e02df in PyUnicode_DecodeUTF8Stateful (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x22c2df)
    #4 0x7f1ac35e682c in PyUnicode_FromFormatV (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x23282c)
    #5 0x7f1ac3567afb in PyErr_Format (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x1b3afb)
    #6 0x7f1ac36126a2 in _PyObject_GenericGetAttrWithDict (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x25e6a2)
    #7 0x7f1ac36130c9 in _PyModuleSpec_IsInitializing (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x25f0c9)
    #8 0x7f1ac343ca78 in PyImport_ImportModuleLevelObject (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x88a78)
    #9 0x7f1ac3559b0c in PyImport_ImportModuleLevel (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x1a5b0c)
    #10 0x7f1ac3559cf4 in PyImport_Import (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x1a5cf4)
    #11 0x7f1ac3559dfd in PyImport_ImportModule (/lib/x86_64-linux-gnu/libpython3.8.so.1.0+0x1a5dfd)
    #12 0x7f1ad8c6c5ab in pyudf::PythonFunction::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::a\
llocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /hom\
e/mark/development/duckdb-python-udf/src/python_function.cpp:28
    #13 0x7f1ad8c6c03b in pyudf::PythonFunction::PythonFunction(std::__cxx11::basic_string<char, std::char_traits<cha\
r>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > co\
nst&) /home/mark/development/duckdb-python-udf/src/python_function.cpp:19
    #14 0x7f1ad8c6f683 in pyudf::PythonTableFunction::PythonTableFunction(std::__cxx11::basic_string<char, std::char_\
traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<\
char> > const&) /home/mark/development/duckdb-python-udf/src/python_table_function.cpp:22
```